### PR TITLE
Disable pylint warnings [part 2]

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -34,5 +34,4 @@ disable =
     too-many-statements,
     unbalanced-tuple-unpacking,
     undefined-variable,
-    unspecified-encoding,
     unused-argument,

--- a/.pylintrc
+++ b/.pylintrc
@@ -6,7 +6,6 @@ disable =
     abstract-method,
     attribute-defined-outside-init,
     bare-except,
-    deprecated-module,
     duplicate-code,
     expression-not-assigned,
     fixme,

--- a/.pylintrc
+++ b/.pylintrc
@@ -34,6 +34,5 @@ disable =
     too-many-statements,
     unbalanced-tuple-unpacking,
     undefined-variable,
-    unnecessary-dunder-call,
     unspecified-encoding,
     unused-argument,

--- a/.pylintrc
+++ b/.pylintrc
@@ -16,7 +16,6 @@ disable =
     invalid-name,
     invalid-unary-operand-type,
     line-too-long,
-    missing-function-docstring,
     no-member,
     pointless-string-statement,
     potential-index-error,

--- a/.pylintrc
+++ b/.pylintrc
@@ -6,7 +6,6 @@ disable =
     abstract-method,
     attribute-defined-outside-init,
     bare-except,
-    chained-comparison,
     deprecated-module,
     duplicate-code,
     expression-not-assigned,

--- a/.pylintrc
+++ b/.pylintrc
@@ -34,7 +34,6 @@ disable =
     too-many-statements,
     unbalanced-tuple-unpacking,
     undefined-variable,
-    unnecessary-comprehension,
     unnecessary-dunder-call,
     unspecified-encoding,
     unused-argument,

--- a/.pylintrc
+++ b/.pylintrc
@@ -33,4 +33,3 @@ disable =
     too-many-statements,
     unbalanced-tuple-unpacking,
     undefined-variable,
-    unused-argument,

--- a/.pylintrc
+++ b/.pylintrc
@@ -20,7 +20,6 @@ disable =
     pointless-string-statement,
     potential-index-error,
     raise-missing-from,
-    redefined-builtin,
     redefined-outer-name,
     too-few-public-methods,
     too-many-arguments,

--- a/ais_area_notice/an_util.py
+++ b/ais_area_notice/an_util.py
@@ -19,6 +19,14 @@ class DecodeBits:
 
     # TODO(schwehr): This method name should be GetUInt.
     def GetInt(self, length):
+        """Read an unsigned integer of specified bit length from the bitstream.
+
+        Args:
+            length: Number of bits to read.
+
+        Returns:
+            The unsigned integer value decoded from the bit slice.
+        """
         end = self.pos + length
         value = int(self.bits[self.pos : end])
         self.pos += length
@@ -26,12 +34,32 @@ class DecodeBits:
 
     # TODO(schwehr): This method name should be GetInt.
     def GetSignedInt(self, length):
+        """Read a signed integer of specified bit length from the bitstream.
+
+        Args:
+            length: Number of bits to read.
+
+        Returns:
+            The signed integer value decoded from the bit slice.
+        """
         end = self.pos + length
         value = binary.signedIntFromBV(self.bits[self.pos : end])
         self.pos += length
         return value
 
     def GetText(self, length, strip=True):
+        """Read 6-bit AIS character text of specified bit length from the bitstream.
+
+        Args:
+            length: Number of bits to read (must be a multiple of 6).
+            strip: Whether to strip padding ('@') characters from the decoded text.
+
+        Returns:
+            The decoded string.
+
+        Raises:
+            Error: If length is not 6-bit aligned.
+        """
         if length % 6 != 0:
             raise Error("Bits for text must be six bit aligned.")
         end = self.pos + length
@@ -43,6 +71,14 @@ class DecodeBits:
         return text
 
     def Verify(self, offset):
+        """Verify that current bit read position matches the expected offset.
+
+        Args:
+            offset: Expected bit position offset.
+
+        Raises:
+            Error: If current bit position does not equal offset.
+        """
         if self.pos != offset:
             raise Error(f"Decode verify failed.  {self.pos} != {offset}")
 
@@ -69,6 +105,12 @@ class BuildBits:
         self.bv_list.append(bits)
 
     def AddText(self, val, num_bits):
+        """Add 6-bit AIS encoded text of specified bit length to the bitstream.
+
+        Args:
+            val: String text to encode.
+            num_bits: Total bit length for the text (must be a multiple of 6).
+        """
         num_char = num_bits // 6
         assert num_bits % 6 == 0
         text = val.ljust(num_char, "@")
@@ -77,10 +119,26 @@ class BuildBits:
         self.bv_list.append(bits)
 
     def Verify(self, num_bits):
+        """Verify that total packed bits match expected bit count.
+
+        Args:
+            num_bits: Expected total bit count.
+
+        Raises:
+            Error: If total packed bits do not match expected count.
+        """
         if self.bits_expected != num_bits:
             raise Error(f"BuildBits did not verify: {self.bits_expected} != {num_bits}")
 
     def GetBits(self):
+        """Concatenate all bit vectors in the list into a single BitVector.
+
+        Returns:
+            The combined BitVector.
+
+        Raises:
+            Error: If combined length does not match expected bit count.
+        """
         bits = binary.joinBV(self.bv_list)
         if len(bits) != self.bits_expected:
             raise Error("BuildBits did not match expected bits.")

--- a/ais_area_notice/build_samples.py
+++ b/ais_area_notice/build_samples.py
@@ -9,6 +9,12 @@ from ais_area_notice import imo_001_26_environment as env
 
 
 def env_dump(e, description):
+    """Print details, bit representations, and NMEA sentences for an environmental report.
+
+    Args:
+        e: The Environment message instance to dump.
+        description: A string description of the test case.
+    """
     print("\n#", description)
     print(e.__str__(verbose=True))
     print("bit_len:", len(e.get_bits()))
@@ -18,6 +24,7 @@ def env_dump(e, description):
 
 
 def env_samples():
+    """Generate and dump various sample environmental report messages."""
     # env each with 1 sensor report
     year = 2011
     month = 6
@@ -297,6 +304,13 @@ def env_samples():
 
 
 def dump_all(area_notice, kmlfile, byte_align=False):
+    """Print representations of an Area Notice and write its KML output.
+
+    Args:
+        area_notice: The AreaNotice instance to dump.
+        kmlfile: An open file handle for writing KML output.
+        byte_align: Whether to byte-align the generated NMEA sentences.
+    """
     print("#", area_notice.name)
     print(str(area_notice))
     for line in area_notice.get_bbm():
@@ -317,6 +331,14 @@ def dump_all(area_notice, kmlfile, byte_align=False):
 
 
 def point(lon, lat, zone_type, kmlfile):
+    """Generate a single point Area Notice sample and output KML.
+
+    Args:
+        lon: Longitude of the point in degrees.
+        lat: Latitude of the point in degrees.
+        zone_type: Area notice zone type identifier.
+        kmlfile: An open file handle for writing KML output.
+    """
     print("# Point")
     pt1 = an.AreaNotice(
         zone_type,

--- a/ais_area_notice/build_samples.py
+++ b/ais_area_notice/build_samples.py
@@ -16,7 +16,7 @@ def env_dump(e, description):
         description: A string description of the test case.
     """
     print("\n#", description)
-    print(e.__str__(verbose=True))
+    print(e.__unicode__(verbose=True))
     print("bit_len:", len(e.get_bits()))
     print("bit_str:", e.get_bits())
     for line in e.get_aivdm(byte_align=True):

--- a/ais_area_notice/imo_001_22_area_notice.py
+++ b/ais_area_notice/imo_001_22_area_notice.py
@@ -1387,8 +1387,8 @@ class AreaNoticePolyline(AreaNoticeSubArea):
             assert lat is not None
             self.decode_bits(bits, lon, lat)
 
-    def decode_bits(self, bits, lon, lat):
-        """lon and lat are the starting point for the point."""
+    def decode_bits(self, bits, _lon=None, _lat=None):
+        """lon and lat are unused for free text subareas."""
 
         if len(bits) != SUB_AREA_SIZE:
             raise AisUnpackingException(f"bit length {len(bits)}")

--- a/ais_area_notice/imo_001_22_area_notice.py
+++ b/ais_area_notice/imo_001_22_area_notice.py
@@ -879,15 +879,15 @@ class AreaNoticeCirclePt(AreaNoticeSubArea):
         @param precision: unless tracking of significant digits to show on a display
         """
         if lon is not None:
-            assert lon >= -180.0 and lon <= 180.0
+            assert -180.0 <= lon <= 180.0
             self.lon = lon
-            assert lat >= -90.0 and lat <= 90.0
+            assert -90.0 <= lat <= 90.0
             self.lat = lat
 
-            assert precision >= 0 and precision <= 4
+            assert 0 <= precision <= 4
             self.precision = precision
 
-            assert radius >= 0 and radius <= 409500
+            assert 0 <= radius <= 409500
             self.radius = radius
 
             if radius / 100.0 >= 4095:
@@ -1036,12 +1036,12 @@ class AreaNoticeRectangle(AreaNoticeSubArea):
         orientation_deg: degrees CW
         """
         if lon is not None:
-            assert lon >= -180.0 and lon <= 180.0
+            assert -180.0 <= lon <= 180.0
             self.lon = lon
-            assert lat >= -90.0 and lat <= 90.0
+            assert -90.0 <= lat <= 90.0
             self.lat = lat
 
-            assert precision >= 0 and precision <= 4
+            assert 0 <= precision <= 4
             self.precision = precision
 
             if east_dim >= 255000 or north_dim >= 255000:
@@ -1198,18 +1198,18 @@ class AreaNoticeSector(AreaNoticeSubArea):
         TODO(schwehr): Should this be raising a ValueError?
         """
         if lon is not None:
-            assert lon >= -180.0 and lon <= 180.0
+            assert -180.0 <= lon <= 180.0
             self.lon = lon
-            assert lat >= -90.0 and lat <= 90.0
+            assert -90.0 <= lat <= 90.0
             self.lat = lat
 
-            assert precision >= 0 and precision <= 4
+            assert 0 <= precision <= 4
             self.precision = precision
 
-            assert 0 <= radius and radius <= 409500
+            assert 0 <= radius <= 409500
 
-            assert 0 <= left_bound_deg and left_bound_deg < 360
-            assert 0 <= right_bound_deg and right_bound_deg < 360
+            assert 0 <= left_bound_deg < 360
+            assert 0 <= right_bound_deg < 360
 
             assert left_bound_deg <= right_bound_deg
 
@@ -1359,16 +1359,16 @@ class AreaNoticePolyline(AreaNoticeSubArea):
         """
 
         if lon is not None:
-            assert lon >= -180.0 and lon <= 180.0
+            assert -180.0 <= lon <= 180.0
             self.lon = lon
-            assert lat >= -90.0 and lat <= 90.0
+            assert -90.0 <= lat <= 90.0
             self.lat = lat
 
         # TODO(schwehr): Check the number of points to make sure we have room
         # and generate multiple subareas if need be.
 
         if points:
-            assert len(points) > 0 and len(points) < 5
+            assert 0 < len(points) < 5
             self.points = points
 
             max_dist = max(pt[1] for pt in points)
@@ -1667,7 +1667,7 @@ class AreaNotice(BBM):
 
         if area_type is not None and when is not None and duration is not None:
             # We are creating a new message
-            assert area_type >= 0 and area_type <= 127
+            assert 0 <= area_type <= 127
             self.area_type = area_type
             assert isinstance(when, datetime.datetime)
             # Be safe with datetime.  We only have 1 minute precision

--- a/ais_area_notice/imo_001_22_area_notice.py
+++ b/ais_area_notice/imo_001_22_area_notice.py
@@ -358,6 +358,14 @@ short_notice = _make_short_notice()
 
 
 def lon_to_utm_zone(lon):
+    """Determine the UTM longitude zone number for a given longitude.
+
+    Args:
+        lon: Longitude in degrees.
+
+    Returns:
+        The UTM zone number (1 to 60).
+    """
     return int((lon + 180) / 6) + 1
 
 
@@ -374,12 +382,29 @@ def ll_to_delta_m(lon1, lat1, lon2, lat2):
 
 
 def dist(p1, p2):
+    """Calculate Euclidean distance between two 2D points.
+
+    Args:
+        p1: Tuple of (x, y) coordinates for the first point.
+        p2: Tuple of (x, y) coordinates for the second point.
+
+    Returns:
+        The Euclidean distance between p1 and p2.
+    """
     return math.sqrt(
         (p1[0] - p2[0]) * (p1[0] - p2[0]) + (p1[1] - p2[1]) * (p1[1] - p2[1])
     )
 
 
 def deltas_to_angle_dist(deltas_m):
+    """Convert sequence of metric offset points to angle and distance pairs.
+
+    Args:
+        deltas_m: List of (dx, dy) coordinate tuples in meters.
+
+    Returns:
+        A list of (angle_degrees, distance_meters) tuples.
+    """
     r = []
     for i in range(1, len(deltas_m)):
         p1 = deltas_m[i - 1]
@@ -393,6 +418,14 @@ def deltas_to_angle_dist(deltas_m):
 
 
 def ll_to_polyline(ll_points):
+    """Convert sequence of (lon, lat) points to polyline relative angle/distance offsets.
+
+    Args:
+        ll_points: List of (lon, lat) tuples (at least 2 points).
+
+    Returns:
+        A list of (angle_degrees, distance_meters) tuples relative to preceding point.
+    """
     # Skips the first point as that is returned as an x, y.  ll==lonlat
     ll = ll_points
     assert len(ll) >= 2
@@ -405,6 +438,15 @@ def ll_to_polyline(ll_points):
 
 
 def polyline_to_ll(start, angles_and_offsets):
+    """Reconstruct absolute (lon, lat) points from start point and offset sequence.
+
+    Args:
+        start: Tuple of (lon, lat) for the initial point.
+        angles_and_offsets: List of (angle_degrees, distance_meters) tuples.
+
+    Returns:
+        A list of (lon, lat) coordinate tuples.
+    """
     # Start lon, lat plus a list of (angle, offset) from that point
     # 0 is true north and runs clockwise
     points = angles_and_offsets
@@ -444,6 +486,15 @@ def frange(start, stop=None, step=None):
 
 
 def vec_add(a, b):
+    """Add two 2D vectors element-wise.
+
+    Args:
+        a: Tuple of (x, y) coordinates.
+        b: Tuple of (x, y) coordinates.
+
+    Returns:
+        A tuple of (a_x + b_x, a_y + b_y).
+    """
     return (a[0] + b[0], a[1] + b[1])
 
 
@@ -538,6 +589,19 @@ class AIVDM:
         raise NotImplementedError()
 
     def get_bits_header(self, message_id=None, repeat_indicator=None, source_mmsi=None):
+        """Construct the standard 38-bit binary header for AIS messages.
+
+        Args:
+            message_id: Optional message ID override (1 to 63).
+            repeat_indicator: Optional repeat indicator override (0 to 3).
+            source_mmsi: Optional source MMSI override.
+
+        Returns:
+            A BitVector containing the 38-bit header payload.
+
+        Raises:
+            AisPackingException: If any header parameter is invalid.
+        """
         if message_id is None:
             message_id = self.message_id
         if repeat_indicator is None:
@@ -846,6 +910,14 @@ class AreaNoticeCirclePt(AreaNoticeSubArea):
         return  # Return an empty object
 
     def decode_bits(self, bits):
+        """Unpack circle/point subarea fields from a BitVector.
+
+        Args:
+            bits: BitVector containing encoded subarea payload.
+
+        Raises:
+            AisUnpackingException: If payload bit length is invalid.
+        """
         if len(bits) != SUB_AREA_SIZE:
             raise AisUnpackingException(f"bit length {len(bits)}")
         if isinstance(bits, str):
@@ -893,6 +965,11 @@ class AreaNoticeCirclePt(AreaNoticeSubArea):
         return f"AreaNoticeCirclePt: Circle centered at ({self.lon:.4f},{self.lat:.4f}) - radius {self.radius}m"
 
     def geom(self):
+        """Construct Shapely geometry representation of this circle or point.
+
+        Returns:
+            A Shapely Point or Polygon geometry.
+        """
         if self.radius <= 0.01:
             return shapely.geometry.Point(self.lon, self.lat)
 
@@ -990,6 +1067,14 @@ class AreaNoticeRectangle(AreaNoticeSubArea):
             self.decode_bits(bits)
 
     def decode_bits(self, bits):
+        """Unpack rectangle subarea fields from a BitVector.
+
+        Args:
+            bits: BitVector containing encoded subarea payload.
+
+        Raises:
+            AisUnpackingException: If payload bit length is invalid.
+        """
         if len(bits) != SUB_AREA_SIZE:
             raise AisUnpackingException(f"bit length {len(bits)}")
         if isinstance(bits, str):
@@ -1014,6 +1099,11 @@ class AreaNoticeRectangle(AreaNoticeSubArea):
         self.spare = int(bits[82:])
 
     def get_bits(self):
+        """Pack rectangle subarea fields into a BitVector payload.
+
+        Returns:
+            A BitVector containing the encoded rectangle subarea payload.
+        """
         bv_list = []
         bv_list.append(binary.setBitVectorSize(BitVector.from_int(self.area_shape), 3))
         bv_list.append(
@@ -1142,6 +1232,14 @@ class AreaNoticeSector(AreaNoticeSubArea):
             self.decode_bits(bits)
 
     def decode_bits(self, bits):
+        """Unpack sector subarea fields from a BitVector.
+
+        Args:
+            bits: BitVector containing encoded subarea payload.
+
+        Raises:
+            AisUnpackingException: If payload bit length is invalid.
+        """
         if len(bits) != SUB_AREA_SIZE:
             raise AisUnpackingException(f"bit length {len(bits)}")
         if isinstance(bits, str):
@@ -1395,6 +1493,11 @@ class AreaNoticePolyline(AreaNoticeSubArea):
         return polyline_to_ll((self.lon, self.lat), self.points)
 
     def geom(self):
+        """Construct Shapely LineString geometry representation of this polyline.
+
+        Returns:
+            A Shapely LineString geometry object.
+        """
         return shapely.geometry.LineString(self.get_points())
 
     @property
@@ -1518,6 +1621,11 @@ class AreaNoticeFreeText(AreaNoticeSubArea):
         return f'AreaNoticeFreeText: "{self.text}"'
 
     def geom(self):
+        """Construct Shapely geometry representation for free text subarea.
+
+        Returns:
+            None as free text does not have explicit spatial geometry.
+        """
         # TODO(schwehr): Should this somehow have a position?
         return None
 
@@ -1671,6 +1779,14 @@ class AreaNotice(BBM):
         return "".join(strings)
 
     def add_subarea(self, area):
+        """Add a subarea shape to this Area Notice.
+
+        Args:
+            area: The subarea shape object to add.
+
+        Raises:
+            AisPackingException: If maximum subarea count (9) is exceeded.
+        """
         if not hasattr(self, "areas"):
             self.areas = []
         if len(self.areas) >= 9:
@@ -2026,6 +2142,7 @@ class NormQueue(Queue.Queue):
 
 
 def main():
+    """Command-line entry point for processing sample NMEA Area Notice messages."""
     parser = optparse.OptionParser(usage="%prog [options]")
 
     _unused_options, args = parser.parse_args()

--- a/ais_area_notice/imo_001_22_area_notice.py
+++ b/ais_area_notice/imo_001_22_area_notice.py
@@ -1722,7 +1722,7 @@ class AreaNotice(BBM):
             l.append(E.LI(str(area)))
         if efactory:
             return
-        return lxml.html.tostring(E.DIV(E.P(self.__str__()), l), encoding="unicode")
+        return lxml.html.tostring(E.DIV(E.P(str(self)), l), encoding="unicode")
 
     @property
     def __geo_interface__(self):

--- a/ais_area_notice/imo_001_26_environment.py
+++ b/ais_area_notice/imo_001_26_environment.py
@@ -470,7 +470,7 @@ class SensorReportWind(SensorReport):
         site_id=None,
         speed=122,
         gust=122,
-        dir=360,
+        dir=360,  # pylint: disable=redefined-builtin
         gust_dir=360,
         data_descr=0,
         forecast_speed=122,

--- a/ais_area_notice/imo_001_26_environment.py
+++ b/ais_area_notice/imo_001_26_environment.py
@@ -259,14 +259,14 @@ class SensorReport:
     def __str__(self):
         return self.__unicode__()
 
-    def decode_bits(self, bits, year=None, month=None, **kwargs):
+    def decode_bits(self, bits, year=None, month=None, **_kwargs):
         """Unpack common sensor report header fields from a BitVector.
 
         Args:
             bits: BitVector containing encoded sensor report bits.
             year: Optional year override. Defaults to current year.
             month: Optional month override. Defaults to current month.
-            **kwargs: Additional unused keyword arguments.
+            **_kwargs: Additional unused keyword arguments.
         """
         assert len(bits) >= SENSOR_REPORT_HDR_SIZE
         assert len(bits) <= SENSOR_REPORT_SIZE
@@ -1569,7 +1569,7 @@ class Environment(BBM):
     def __init__(
         self,
         source_mmsi=None,
-        name=None,
+        _name=None,
         nmea_strings=None,
         bits=None,
     ):
@@ -1704,7 +1704,7 @@ class Environment(BBM):
         except (AttributeError, TypeError):
             raise AisUnpackingException(f"NMEA line malformed: {strings} ")
 
-    def decode_bits(self, bits, year=None):
+    def decode_bits(self, bits, _year=None):
         """Decode the bits for a message."""
 
         # TODO(schwehr): Handle the option of without AIS hdr and message 8 hdr.

--- a/ais_area_notice/imo_001_26_environment.py
+++ b/ais_area_notice/imo_001_26_environment.py
@@ -134,6 +134,16 @@ data_timeout_hrs_lut = {
 
 
 def almost_equal(a, b, epsilon=0.001):
+    """Check if two numbers are equal within a specified epsilon tolerance.
+
+    Args:
+        a: First numeric value.
+        b: Second numeric value.
+        epsilon: Maximum allowed absolute difference between a and b.
+
+    Returns:
+        True if the absolute difference is less than epsilon, None otherwise.
+    """
     if (a < b + epsilon) and (a > b - epsilon):
         return True
 
@@ -226,6 +236,11 @@ class SensorReport:
         return True
 
     def get_date(self):
+        """Construct a datetime object from report timestamp fields.
+
+        Returns:
+            A datetime object for the sensor report timestamp.
+        """
         # TODO(schwehr): Add the UTC timezone?
         return datetime.datetime(
             self.year, self.month, self.day, self.hour, self.minute
@@ -245,6 +260,14 @@ class SensorReport:
         return self.__unicode__()
 
     def decode_bits(self, bits, year=None, month=None, **kwargs):
+        """Unpack common sensor report header fields from a BitVector.
+
+        Args:
+            bits: BitVector containing encoded sensor report bits.
+            year: Optional year override. Defaults to current year.
+            month: Optional month override. Defaults to current month.
+            **kwargs: Additional unused keyword arguments.
+        """
         assert len(bits) >= SENSOR_REPORT_HDR_SIZE
         assert len(bits) <= SENSOR_REPORT_SIZE
 
@@ -265,6 +288,11 @@ class SensorReport:
         self.month = month
 
     def get_bits(self):
+        """Encode common sensor report header fields into a BitVector.
+
+        Returns:
+            A BitVector containing header bits (report type, day, hour, minute, site ID).
+        """
         bv_list = []
         bv_list.append(BitVector.from_int(self.report_type, size=4))
         bv_list.append(BitVector.from_int(self.day, size=5))
@@ -1604,6 +1632,11 @@ class Environment(BBM):
         raise NotImplementedError
 
     def append(self, report):
+        """Append a sensor report to the environment message.
+
+        Args:
+            report: The SensorReport object to append.
+        """
         self.add_sensor_report(report)
 
     def add_sensor_report(self, report):
@@ -1616,6 +1649,11 @@ class Environment(BBM):
         self.sensor_reports.append(report)
 
     def get_report_types(self):
+        """Get the list of sensor report type IDs in this environment message.
+
+        Returns:
+            A list of integer report type identifiers.
+        """
         s = []
         for sr in self.sensor_reports:
             s.append(sr.report_type)

--- a/ais_area_notice/imo_001_26_environment.py
+++ b/ais_area_notice/imo_001_26_environment.py
@@ -144,7 +144,7 @@ def almost_equal(a, b, epsilon=0.001):
     Returns:
         True if the absolute difference is less than epsilon, None otherwise.
     """
-    if (a < b + epsilon) and (a > b - epsilon):
+    if b - epsilon < a < b + epsilon:
         return True
 
 
@@ -197,12 +197,12 @@ class SensorReport:
                 minute = now.minute
 
         assert report_type in sensor_report_lut
-        assert year >= 2010 and year <= 2100
-        assert month >= 1 and month <= 12
-        assert day >= 1 and day <= 31
-        assert hour >= 0 and hour <= 23
-        assert minute >= 0 and minute <= 59
-        assert site_id >= 0 and site_id <= 127
+        assert 2010 <= year <= 2100
+        assert 1 <= month <= 12
+        assert 1 <= day <= 31
+        assert 0 <= hour <= 23
+        assert 0 <= minute <= 59
+        assert 0 <= site_id <= 127
 
         self.report_type = report_type
         self.year = year
@@ -282,8 +282,8 @@ class SensorReport:
             year = now.year
             month = now.month
 
-        assert year >= 2010 and year <= 2100
-        assert month >= 1 and month <= 12
+        assert 2010 <= year <= 2100
+        assert 1 <= month <= 12
         self.year = year
         self.month = month
 
@@ -329,11 +329,11 @@ class SensorReportLocation(SensorReport):
         if bits is not None:
             self.decode_bits(bits)
             return
-        assert (lon >= -180.0 and lon <= 180.0) or lon == 181
-        assert (lat >= -90.0 and lat <= 90.0) or lat == 91
-        assert alt >= 0 and alt < 200.3  # 2002 is not-available
-        assert (owner >= 0 and owner <= 6) or owner == 14
-        assert timeout >= 0 and timeout <= 5
+        assert -180.0 <= lon <= 180.0 or lon == 181
+        assert -90.0 <= lat <= 90.0 or lat == 91
+        assert 0 <= alt < 200.3  # 2002 is not-available
+        assert 0 <= owner <= 6 or owner == 14
+        assert 0 <= timeout <= 5
         assert site_id is not None
 
         SensorReport.__init__(
@@ -628,18 +628,18 @@ class SensorReportWaterLevel(SensorReport):
             return
 
         assert wl_type in (0, 1)
-        assert wl >= -327.68 and wl <= 327.68  # TODO(schwehr): need? + 0.001)
-        assert wl >= -327.68 and wl <= 327.68  # TODO(schwehr): need? + 0.001)
+        assert -327.68 <= wl <= 327.68  # TODO(schwehr): need? + 0.001)
+        assert -327.68 <= wl <= 327.68  # TODO(schwehr): need? + 0.001)
         assert trend in (0, 1, 2, 3)
-        assert vdatum >= 0 and vdatum <= 14
+        assert 0 <= vdatum <= 14
         assert data_descr in sensor_type_lut
         assert forecast_type in (0, 1)
         # TODO(schwehr): Need a buffer for floats? + 0.001)
-        assert forecast_wl >= -327.68 and forecast_wl <= 327.68
-        assert forecast_day >= 0 and forecast_day <= 31
-        assert forecast_hour >= 0 and forecast_hour <= 24
-        assert forecast_minute >= 0 and forecast_minute <= 60
-        assert duration_min >= 0 and duration_min <= 255
+        assert -327.68 <= forecast_wl <= 327.68
+        assert 0 <= forecast_day <= 31
+        assert 0 <= forecast_hour <= 24
+        assert 0 <= forecast_minute <= 60
+        assert 0 <= duration_min <= 255
 
         self.wl_type = wl_type
         self.wl = wl
@@ -776,9 +776,9 @@ class SensorReportCurrent2d(SensorReport):
         self.data_descr = data_descr
 
         for cur in self.cur:
-            assert cur["speed"] >= 0 and cur["speed"] <= 24.7
-            assert cur["dir"] >= 0 and cur["dir"] <= 360
-            assert cur["level"] >= 0 and cur["level"] <= 362
+            assert 0 <= cur["speed"] <= 24.7
+            assert 0 <= cur["dir"] <= 360
+            assert 0 <= cur["level"] <= 362
         assert data_descr in sensor_type_lut
 
         SensorReport.__init__(
@@ -874,9 +874,9 @@ class SensorReportCurrent3d(SensorReport):
         self.data_descr = data_descr
 
         for cur in self.cur:
-            assert cur["level"] >= 0 and cur["level"] <= 362
+            assert 0 <= cur["level"] <= 362
             for x in ("n", "e", "z"):
-                assert cur[x] >= 0 and cur[x] <= 24.7
+                assert 0 <= cur[x] <= 24.7
         assert data_descr in sensor_type_lut
 
         SensorReport.__init__(
@@ -985,10 +985,10 @@ class SensorReportCurrentHorz(SensorReport):
         ]
 
         for cur in self.cur:
-            assert cur["dist"] >= 0 and cur["dist"] <= 122
-            assert cur["level"] >= 0 and cur["level"] <= 361
+            assert 0 <= cur["dist"] <= 122
+            assert 0 <= cur["level"] <= 361
             for field in ("bearing", "dir"):
-                assert cur[field] >= 0 and cur[field] <= 360
+                assert 0 <= cur[field] <= 360
 
         SensorReport.__init__(
             self,
@@ -1082,20 +1082,20 @@ class SensorReportSeaState(SensorReport):
             self.decode_bits(bits)
             return
 
-        assert swell_height >= 0 and swell_height <= 24.7
-        assert swell_period >= 0 and swell_period <= 61
-        assert swell_dir >= 0 and swell_dir <= 361
+        assert 0 <= swell_height <= 24.7
+        assert 0 <= swell_period <= 61
+        assert 0 <= swell_dir <= 361
         assert sea_state in beaufort_scale
         assert swell_data_descr in sensor_type_lut
 
-        assert temp >= -10.0 and temp <= 50.1
-        assert temp_depth >= 0 and temp_depth <= 12.2
+        assert -10.0 <= temp <= 50.1
+        assert 0 <= temp_depth <= 12.2
         assert temp_data_descr in sensor_type_lut
-        assert wave_height >= 0 and wave_height <= 24.7
-        assert wave_period >= 0 and wave_period <= 61
-        assert wave_dir >= 0 and wave_dir <= 361
+        assert 0 <= wave_height <= 24.7
+        assert 0 <= wave_period <= 61
+        assert 0 <= wave_dir <= 361
         assert wave_data_descr in sensor_type_lut
-        assert salinity >= 0 and salinity <= 50.2
+        assert 0 <= salinity <= 50.2
 
         self.swell_height = swell_height
         self.swell_period = swell_period
@@ -1228,13 +1228,13 @@ class SensorReportSalinity(SensorReport):
             return
 
         assert (
-            (temp >= -10.0 and temp <= 50.0)
+            -10.0 <= temp <= 50.0
             or almost_equal(temp, 60.1)
             or almost_equal(temp, 60.2)
         )
-        assert cond >= 0.0 and cond <= 7.03
-        assert pres >= 0.0 and pres <= 6000.3
-        assert salinity >= 0.0 and salinity <= 50.3
+        assert 0.0 <= cond <= 7.03
+        assert 0.0 <= pres <= 6000.3
+        assert 0.0 <= salinity <= 50.3
         assert salinity_type in (0, 1, 2)
         assert data_descr in sensor_type_lut
 
@@ -1340,18 +1340,16 @@ class SensorReportWeather(SensorReport):
             self.decode_bits(bits)
             return
 
-        assert (air_temp >= -60.0 and air_temp <= 60.0) or almost_equal(
-            air_temp, -102.4
-        )
+        assert -60.0 <= air_temp <= 60.0 or almost_equal(air_temp, -102.4)
         assert air_temp_data_descr in sensor_type_lut
         assert precip in (0, 1, 2, 3)
-        assert vis >= 0.0 and vis <= 24.3
-        assert dew >= -20.0 and dew <= 50.1
+        assert 0.0 <= vis <= 24.3
+        assert -20.0 <= dew <= 50.1
         assert dew_data_descr in sensor_type_lut
-        assert air_pres >= 800 and air_pres <= 1202
+        assert 800 <= air_pres <= 1202
         assert air_pres_trend in (0, 1, 2, 3)
         assert air_pres_data_descr in sensor_type_lut
-        assert salinity >= 0.0 and salinity <= 50.2
+        assert 0.0 <= salinity <= 50.2
 
         self.air_temp = air_temp
         self.air_temp_data_descr = air_temp_data_descr
@@ -1477,15 +1475,13 @@ class SensorReportAirGap(SensorReport):
             return
 
         # TODO(schwehr): Are draft and gap are in 0.01 meter incrememts?
-        assert (draft >= 1.0 and draft <= 81.91) or almost_equal(draft, 0)
-        assert (gap >= 1.0 and gap <= 81.91) or almost_equal(gap, 0)
+        assert (1.0 <= draft <= 81.91) or almost_equal(draft, 0)
+        assert (1.0 <= gap <= 81.91) or almost_equal(gap, 0)
         assert gap_trend in (0, 1, 2, 3)
-        assert (forecast_gap >= 1.0 and forecast_gap <= 81.91) or almost_equal(
-            forecast_gap, 0
-        )
-        assert forecast_day >= 0 and forecast_day <= 31
-        assert forecast_hour >= 0 and forecast_hour <= 24
-        assert forecast_minute >= 0 and forecast_minute <= 60
+        assert (1.0 <= forecast_gap <= 81.91) or almost_equal(forecast_gap, 0)
+        assert 0 <= forecast_day <= 31
+        assert 0 <= forecast_hour <= 24
+        assert 0 <= forecast_minute <= 60
 
         self.draft = draft
         self.gap = gap

--- a/ais_area_notice/imo_001_31_met_hydro.py
+++ b/ais_area_notice/imo_001_31_met_hydro.py
@@ -342,7 +342,7 @@ class MetHydro31(BBM):
         # TODO(schwehr): Decode the NMEA.
         raise NotImplementedError
 
-    def decode_bits(self, bits, year=None):
+    def decode_bits(self, bits, _year=None):
         """Decode the bits for a message."""
 
         # TODO: Pass these through and verify.

--- a/ais_area_notice/imo_001_31_met_hydro.py
+++ b/ais_area_notice/imo_001_31_met_hydro.py
@@ -119,48 +119,46 @@ class MetHydro31(BBM):
                 minute = now.minute
 
         assert source_mmsi is not None and 100000 <= source_mmsi <= 999999999
-        assert (lon >= -180.0 and lon <= 180.0) or lon == 181
-        assert (lat >= -90.0 and lat <= 90.0) or lat == 91
-        assert day >= 0 and day <= 31
-        assert hour >= 0 and hour <= 24
-        assert minute >= 0 and minute <= 60
-        assert wind >= 0 and wind <= 127
-        assert gust >= 0 and gust <= 127
-        assert wind_dir >= 0 and wind_dir <= 360
-        assert gust_dir >= 0 and gust_dir <= 360
-        assert (air_temp >= -60.0 and air_temp <= 60.0) or air_temp == -102.4
-        assert humid >= 0 and humid <= 101
+        assert -180.0 <= lon <= 180.0 or lon == 181
+        assert -90.0 <= lat <= 90.0 or lat == 91
+        assert 0 <= day <= 31
+        assert 0 <= hour <= 24
+        assert 0 <= minute <= 60
+        assert 0 <= wind <= 127
+        assert 0 <= gust <= 127
+        assert 0 <= wind_dir <= 360
+        assert 0 <= gust_dir <= 360
+        assert -60.0 <= air_temp <= 60.0 or air_temp == -102.4
+        assert 0 <= humid <= 101
         # Warning: different than air_temp.
-        assert dew >= -20.0 and dew <= 50.1
+        assert -20.0 <= dew <= 50.1
         # TODO(schwehr): Check the last val of air pressure.
-        assert (air_pres >= 800 and air_pres <= 1201) or air_pres == 399 + 510
+        assert 800 <= air_pres <= 1201 or air_pres == 399 + 510
         assert air_pres_trend in (0, 1, 2, 3)
-        assert vis >= 0.0 and vis <= 12.7
-        assert wl >= -10.0 and wl <= 30.1
+        assert 0.0 <= vis <= 12.7
+        assert -10.0 <= wl <= 30.1
         assert wl_trend in (0, 1, 2, 3)
-        assert (cur_1 >= 0 and cur_1 <= 25.1) or cur_1 == 25.5
-        assert cur_dir_1 >= 0 and cur_dir_1 <= 360
+        assert 0 <= cur_1 <= 25.1 or cur_1 == 25.5
+        assert 0 <= cur_dir_1 <= 360
         # Level 1 is 0.
-        assert (cur_2 >= 0 and cur_2 <= 25.1) or cur_2 == 25.5
-        assert cur_dir_2 >= 0 and cur_dir_2 <= 360
-        assert cur_level_2 >= 0 and cur_level_2 <= 31
-        assert (cur_3 >= 0 and cur_3 <= 25.1) or cur_3 == 25.5
-        assert cur_dir_3 >= 0 and cur_dir_3 <= 360
-        assert cur_level_3 >= 0 and cur_level_3 <= 31
+        assert 0 <= cur_2 <= 25.1 or cur_2 == 25.5
+        assert 0 <= cur_dir_2 <= 360
+        assert 0 <= cur_level_2 <= 31
+        assert 0 <= cur_3 <= 25.1 or cur_3 == 25.5
+        assert 0 <= cur_dir_3 <= 360
+        assert 0 <= cur_level_3 <= 31
 
-        assert (wave_height >= 0 and wave_height <= 25.1) or wave_height == 25.5
-        assert (wave_period >= 0 and wave_period <= 60) or wave_period == 63
-        assert wave_dir >= 0 and wave_dir <= 360
-        assert (swell_height >= 0 and swell_height <= 25.1) or swell_height == 25.5
-        assert (swell_period >= 0 and swell_period <= 60) or swell_period == 63
-        assert swell_dir >= 0 and swell_dir <= 360
+        assert 0 <= wave_height <= 25.1 or wave_height == 25.5
+        assert 0 <= wave_period <= 60 or wave_period == 63
+        assert 0 <= wave_dir <= 360
+        assert 0 <= swell_height <= 25.1 or swell_height == 25.5
+        assert 0 <= swell_period <= 60 or swell_period == 63
+        assert 0 <= swell_dir <= 360
         assert sea_state in beaufort_scale
 
-        assert water_temp >= -10.0 and water_temp <= 50.1
+        assert -10.0 <= water_temp <= 50.1
         assert precip in precip_types
-        assert (
-            (salinity >= 0 and salinity <= 50.1) or salinity == 51.0 or salinity == 51.1
-        )
+        assert 0 <= salinity <= 50.1 or salinity == 51.0 or salinity == 51.1
 
         self.source_mmsi = source_mmsi
         self.lon = lon

--- a/ais_area_notice/m366_22.py
+++ b/ais_area_notice/m366_22.py
@@ -38,6 +38,14 @@ class AreaNoticeSubArea:
     """Base class for subarea shapes in USCG 8:366:22 Area Notices."""
 
     def getScaleFactor(self, value):
+        """Determine scale factor for a numeric value.
+
+        Args:
+            value: Distance or length value to scale.
+
+        Returns:
+            The scaling factor multiplier (1, 10, 100, or 1000).
+        """
         if value / 100.0 >= 4095:
             return 1000
         if value / 10.0 > 4095:
@@ -47,9 +55,25 @@ class AreaNoticeSubArea:
         return 1
 
     def getScaleFactorRaw(self, scale_factor):
+        """Map scale factor multiplier to 2-bit raw integer encoding.
+
+        Args:
+            scale_factor: Integer scale factor (1, 10, 100, or 1000).
+
+        Returns:
+            The 2-bit integer encoding (0, 1, 2, or 3).
+        """
         return {1: 0, 10: 1, 100: 2, 1000: 3}[scale_factor]
 
     def decodeScaleFactor(self, db):
+        """Decode 2-bit raw scale factor from bitstream reader into multiplier.
+
+        Args:
+            db: DecodeBits bitstream streamer object.
+
+        Returns:
+            The decoded scale factor multiplier (1, 10, 100, or 1000).
+        """
         scale_factor_raw = db.GetInt(2)
         return (1, 10, 100, 1000)[scale_factor_raw]
 
@@ -77,6 +101,11 @@ class AreaNoticeCircle(AreaNoticeSubArea):
             raise Error("Must specify bits or parameters.")
 
     def DecodeBits(self, bits):
+        """Unpack circle subarea shape fields from a BitVector.
+
+        Args:
+            bits: BitVector containing encoded subarea bits.
+        """
         logging.info("areanotice CIRCLE - decode bits %d %s", len(bits), bits)
         db = an_util.DecodeBits(bits)
         self.area_shape = db.GetInt(3)
@@ -91,6 +120,11 @@ class AreaNoticeCircle(AreaNoticeSubArea):
         db.Verify(SUB_AREA_BIT_SIZE)
 
     def get_bits(self):
+        """Pack circle subarea shape fields into a BitVector.
+
+        Returns:
+            A BitVector containing the encoded circle subarea payload.
+        """
         bb = an_util.BuildBits()
         bb.AddUInt(SHAPES["CIRCLE"], 3)
         if "scale_factor" not in self.__dict__:
@@ -144,6 +178,14 @@ class AreaNotice:
             raise Error("Must specify nmea_strings or area_type.")
 
     def add_subarea(self, area):
+        """Add a subarea shape to the Area Notice message.
+
+        Args:
+            area: Subarea shape object to append.
+
+        Raises:
+            AisPackingException: If maximum allowed subareas count is exceeded.
+        """
         if not hasattr(self, "areas"):
             self.areas = []
         if len(self.areas) > self.max_areas:
@@ -153,6 +195,14 @@ class AreaNotice:
         self.areas.append(area)
 
     def decode_nmea(self, strings):
+        """Decode NMEA 0183 AIVDM sentence strings into this Area Notice message.
+
+        Args:
+            strings: List of NMEA sentence strings.
+
+        Raises:
+            AisUnpackingException: If sentence parsing or checksum verification fails.
+        """
         try:
             msgs = []
             for msg in strings:
@@ -181,6 +231,14 @@ class AreaNotice:
         self.DecodeBits(bits)
 
     def DecodeBits(self, bits):
+        """Unpack Area Notice fields from a BitVector payload.
+
+        Args:
+            bits: BitVector containing the encoded binary payload.
+
+        Raises:
+            Error: If message headers or subarea counts are invalid.
+        """
         db = an_util.DecodeBits(bits)
         self.message_id = db.GetInt(6)
         self.repeat_indicator = db.GetInt(2)
@@ -221,6 +279,18 @@ class AreaNotice:
             self.add_subarea(subarea)
 
     def SubareaFactory(self, bits):
+        """Instantiate appropriate subarea shape object from raw bit slice.
+
+        Args:
+            bits: BitVector containing encoded subarea bits.
+
+        Returns:
+            An AreaNoticeSubArea subclass instance.
+
+        Raises:
+            AisPackingException: If polyline/polygon sequencing requirements fail.
+            Error: If shape type is unsupported.
+        """
         shape = int(bits[:3])
         if shape == 0:
             return AreaNoticeCircle(bits=bits)

--- a/ais_area_notice/m367_22.py
+++ b/ais_area_notice/m367_22.py
@@ -39,6 +39,14 @@ class DecodeBits:
 
     # TODO(schwehr): This should be GetUInt.
     def GetInt(self, length):
+        """Read an unsigned integer of specified bit length from the bitstream.
+
+        Args:
+            length: Number of bits to read.
+
+        Returns:
+            The unsigned integer value decoded from the bit slice.
+        """
         end = self.pos + length
         value = int(self.bits[self.pos : end])
         self.pos += length
@@ -46,12 +54,29 @@ class DecodeBits:
 
     # TODO(schwehr): This should be GetInt.
     def GetSignedInt(self, length):
+        """Read a signed integer of specified bit length from the bitstream.
+
+        Args:
+            length: Number of bits to read.
+
+        Returns:
+            The signed integer value decoded from the bit slice.
+        """
         end = self.pos + length
         value = binary.signedIntFromBV(self.bits[self.pos : end])
         self.pos += length
         return value
 
     def GetText(self, length, strip=True):
+        """Read 6-bit AIS character text of specified bit length from the bitstream.
+
+        Args:
+            length: Number of bits to read (must be a multiple of 6).
+            strip: Whether to strip padding ('@') characters from the decoded text.
+
+        Returns:
+            The decoded string.
+        """
         assert length % 6 == 0
         end = self.pos + length
         text = ais_string.Decode(self.bits[self.pos : end])
@@ -62,6 +87,11 @@ class DecodeBits:
         return text
 
     def Verify(self, offset):
+        """Verify that current bit read position matches the expected offset.
+
+        Args:
+            offset: Expected bit position offset.
+        """
         if self.pos != offset:
             logging.info("DecodeBits FAILING!  expect: %s got: %s", offset, self.pos)
         assert self.pos == offset
@@ -89,6 +119,12 @@ class BuildBits:
         self.bv_list.append(bits)
 
     def AddText(self, val, num_bits):
+        """Add 6-bit AIS encoded text of specified bit length to the bitstream.
+
+        Args:
+            val: String text to encode.
+            num_bits: Total bit length for the text (must be a multiple of 6).
+        """
         num_char = num_bits // 6
         assert num_bits % 6 == 0
         text = val.ljust(num_char, "@")
@@ -97,9 +133,19 @@ class BuildBits:
         self.bv_list.append(bits)
 
     def Verify(self, num_bits):
+        """Verify that total packed bits match expected bit count.
+
+        Args:
+            num_bits: Expected total bit count.
+        """
         assert self.bits_expected == num_bits
 
     def GetBits(self):
+        """Concatenate all bit vectors in the list into a single BitVector.
+
+        Returns:
+            The combined BitVector.
+        """
         bits = binary.joinBV(self.bv_list)
         assert len(bits) == self.bits_expected
         return bits
@@ -126,6 +172,14 @@ class AreaNoticeSubArea:
         return {1: 0, 10: 1, 100: 2, 1000: 3}[scale_factor]
 
     def decodeScaleFactor(self, db):
+        """Decode 2-bit raw scale factor from bitstream reader into multiplier.
+
+        Args:
+            db: DecodeBits bitstream streamer object.
+
+        Returns:
+            The decoded scale factor multiplier (1, 10, 100, or 1000).
+        """
         scale_factor_raw = db.GetInt(2)
         return (1, 10, 100, 1000)[scale_factor_raw]
 
@@ -152,6 +206,11 @@ class AreaNoticeCircle(AreaNoticeSubArea):
         # TODO(schwehr): Warn for else.
 
     def decode_bits(self, bits):
+        """Unpack circle subarea shape fields from a BitVector.
+
+        Args:
+            bits: BitVector containing encoded subarea bits.
+        """
         assert len(bits) == SUB_AREA_SIZE
         db = DecodeBits(bits)
         self.area_shape = db.GetInt(3)
@@ -165,6 +224,11 @@ class AreaNoticeCircle(AreaNoticeSubArea):
         db.Verify(SUB_AREA_SIZE)
 
     def get_bits(self):
+        """Pack circle subarea shape fields into a BitVector.
+
+        Returns:
+            A BitVector containing the encoded circle subarea payload.
+        """
         bb = BuildBits()
         bb.AddUInt(SHAPES["CIRCLE"], 3)  # Area shape
         if "scale_factor" not in self.__dict__:
@@ -216,6 +280,11 @@ class AreaNoticeRectangle(AreaNoticeSubArea):
             self.decode_bits(bits)
 
     def decode_bits(self, bits):
+        """Unpack rectangle subarea shape fields from a BitVector.
+
+        Args:
+            bits: BitVector containing encoded subarea bits.
+        """
         db = DecodeBits(bits)
         self.area_shape = db.GetInt(3)
         self.scale_factor = self.decodeScaleFactor(db)
@@ -231,6 +300,11 @@ class AreaNoticeRectangle(AreaNoticeSubArea):
         db.Verify(SUB_AREA_SIZE)
 
     def get_bits(self):
+        """Pack rectangle subarea shape fields into a BitVector.
+
+        Returns:
+            A BitVector containing the encoded rectangle subarea payload.
+        """
         bb = BuildBits()
         bb.AddUInt(SHAPES["RECTANGLE"], 3)
         if "scale_factor" not in self.__dict__:
@@ -279,6 +353,11 @@ class AreaNoticeSector(AreaNoticeSubArea):
             self.decode_bits(bits)
 
     def decode_bits(self, bits):
+        """Unpack sector subarea shape fields from a BitVector.
+
+        Args:
+            bits: BitVector containing encoded subarea bits.
+        """
         db = DecodeBits(bits)
         self.area_shape = db.GetInt(3)
         self.scale_factor = self.decodeScaleFactor(db)
@@ -294,6 +373,11 @@ class AreaNoticeSector(AreaNoticeSubArea):
         db.Verify(SUB_AREA_SIZE)
 
     def get_bits(self):
+        """Pack sector subarea shape fields into a BitVector.
+
+        Returns:
+            A BitVector containing the encoded sector subarea payload.
+        """
         bb = BuildBits()
         bb.AddUInt(SHAPES["SECTOR"], 3)
         if "scale_factor" not in self.__dict__:
@@ -340,6 +424,11 @@ class AreaNoticePoly(AreaNoticeSubArea):
             self.decode_bits(bits)
 
     def decode_bits(self, bits):
+        """Unpack polyline/polygon subarea shape fields from a BitVector.
+
+        Args:
+            bits: BitVector containing encoded subarea bits.
+        """
         assert len(bits) == SUB_AREA_SIZE
         db = DecodeBits(bits)
         self.area_shape = db.GetInt(3)
@@ -364,6 +453,11 @@ class AreaNoticePoly(AreaNoticeSubArea):
         db.Verify(SUB_AREA_SIZE)
 
     def get_bits(self):
+        """Pack polyline/polygon subarea shape fields into a BitVector.
+
+        Returns:
+            A BitVector containing the encoded polyline/polygon subarea payload.
+        """
         bb = BuildBits()
         assert self.area_shape in (SHAPES["POLYLINE"], SHAPES["POLYGON"])
         bb.AddUInt(self.area_shape, 3)
@@ -393,6 +487,11 @@ class AreaNoticeText(AreaNoticeSubArea):
             self.decode_bits(bits)
 
     def decode_bits(self, bits):
+        """Unpack free text subarea shape fields from a BitVector.
+
+        Args:
+            bits: BitVector containing encoded subarea bits.
+        """
         db = DecodeBits(bits)
         self.area_shape = db.GetInt(3)
         self.text = db.GetText(90, strip=True)
@@ -400,6 +499,11 @@ class AreaNoticeText(AreaNoticeSubArea):
         db.Verify(SUB_AREA_SIZE)
 
     def get_bits(self):
+        """Pack free text subarea shape fields into a BitVector.
+
+        Returns:
+            A BitVector containing the encoded free text subarea payload.
+        """
         bb = BuildBits()
         bb.AddUInt(SHAPES["TEXT"], 3)
         bb.AddText(self.text, 90)
@@ -444,6 +548,14 @@ class AreaNotice(BBM):
             self.source_mmsi = self.mmsi  # TODO(schwehr): Make all just mmsi.
 
     def add_subarea(self, area):
+        """Add a subarea shape to the Area Notice message.
+
+        Args:
+            area: Subarea shape object to append.
+
+        Raises:
+            AisPackingException: If maximum allowed subareas count is exceeded.
+        """
         if not hasattr(self, "areas"):
             self.areas = []
         if len(self.areas) > self.max_areas:
@@ -453,6 +565,18 @@ class AreaNotice(BBM):
         self.areas.append(area)
 
     def get_bits(self, include_bin_hdr=False, include_dac_fi=True):
+        """Pack Area Notice message fields and subareas into a BitVector.
+
+        Args:
+            include_bin_hdr: Whether to include standard AIS binary header.
+            include_dac_fi: Whether to include DAC and FI fields.
+
+        Returns:
+            A BitVector containing the encoded binary payload.
+
+        Raises:
+            AisPackingException: If message size exceeds maximum bit limit.
+        """
         bv_list = []
         if include_bin_hdr:
             # Messages ID
@@ -488,6 +612,14 @@ class AreaNotice(BBM):
         return bv
 
     def decode_nmea(self, strings):
+        """Decode NMEA 0183 AIVDM sentence strings into this Area Notice message.
+
+        Args:
+            strings: List of NMEA sentence strings.
+
+        Raises:
+            AisUnpackingException: If sentence parsing or checksum verification fails.
+        """
         try:
             msgs = []
             for msg in strings:
@@ -516,6 +648,11 @@ class AreaNotice(BBM):
         self.decode_bits(bits)
 
     def decode_bits(self, bits):
+        """Unpack Area Notice fields from a BitVector payload.
+
+        Args:
+            bits: BitVector containing the encoded binary payload.
+        """
         db = DecodeBits(bits)
         self.message_id = db.GetInt(6)
         self.repeat_indicator = db.GetInt(2)
@@ -552,6 +689,17 @@ class AreaNotice(BBM):
             self.add_subarea(subarea)
 
     def subarea_factory(self, bits):
+        """Instantiate appropriate subarea shape object from raw bit slice.
+
+        Args:
+            bits: BitVector containing encoded subarea bits.
+
+        Returns:
+            An AreaNoticeSubArea subclass instance.
+
+        Raises:
+            AisPackingException: If polyline/polygon sequencing requirements fail.
+        """
         shape = int(bits[:3])
         if shape == 0:
             return AreaNoticeCircle(bits=bits)

--- a/ais_area_notice/make_kml_styles.py
+++ b/ais_area_notice/make_kml_styles.py
@@ -13,6 +13,11 @@ def hex_len2(h):
 
 
 def rand_hex_color():
+    """Generate a random 6-character hex color string.
+
+    Returns:
+        A 6-character hexadecimal color string.
+    """
     return "".join(
         [hex_len2(hex(int(random.random() * 255)).split("x")[1]) for j in range(3)]
     )

--- a/tests/ais_string_test.py
+++ b/tests/ais_string_test.py
@@ -8,6 +8,7 @@ from ais_area_notice import ais_string
 
 
 def test_strip():
+    """Test stripping trailing padding characters and spaces from AIS strings."""
     assert ais_string.Strip("") == ""
     assert ais_string.Strip("@") == ""
     assert ais_string.Strip("A@") == "A"
@@ -20,6 +21,7 @@ def test_strip():
 
 
 def test_pad():
+    """Test padding AIS strings to a specified character length with '@'."""
     assert ais_string.Pad("", 0) == ""
     assert ais_string.Pad("", 1) == "@"
     assert ais_string.Pad("A", 1) == "A"
@@ -28,6 +30,7 @@ def test_pad():
 
 
 def test_round_trip():
+    """Test encoding and decoding AIS strings preserves original content."""
     strings = ("", " ", "@", " @", "A", "A@A")
     for string in strings:
         encoded = ais_string.Encode(string)
@@ -35,16 +38,19 @@ def test_round_trip():
 
 
 def test_decode_drop_after_first_at():
+    """Test decoding AIS strings with drop_after_first_at set to True."""
     encoded = ais_string.Encode("A@A")
     assert ais_string.Decode(encoded, drop_after_first_at=True) == "A"
 
 
 def test_encode_bit_size_padding():
+    """Test encoding AIS strings with explicit bit_size padding."""
     encoded = ais_string.Encode("A", bit_size=12)
     assert len(encoded) == 12
     assert str(encoded) == "000001000000"
 
 
 def test_encode_bit_size_too_small():
+    """Test encoding AIS strings raises error when bit_size is too small."""
     with pytest.raises(AssertionError):
         ais_string.Encode("AB", bit_size=6)

--- a/tests/an_util_test.py
+++ b/tests/an_util_test.py
@@ -7,6 +7,7 @@ from ais_area_notice import an_util
 
 
 def test_decode_bits_get_int():
+    """Test DecodeBits.GetInt reads unsigned integers sequentially."""
     bv = BitVector.from_bitstring("00010100")
     db = an_util.DecodeBits(bv)
     assert db.GetInt(4) == 1
@@ -15,6 +16,7 @@ def test_decode_bits_get_int():
 
 
 def test_decode_bits_get_signed_int():
+    """Test DecodeBits.GetSignedInt reads signed integers sequentially."""
     bv = BitVector.from_bitstring("00101110")
     db = an_util.DecodeBits(bv)
     assert db.GetSignedInt(4) == 2
@@ -23,6 +25,7 @@ def test_decode_bits_get_signed_int():
 
 
 def test_decode_bits_get_text_strip():
+    """Test DecodeBits.GetText with strip=True strips padding '@' characters."""
     bv = BitVector.from_bitstring("000001000000000010")
     db = an_util.DecodeBits(bv)
     assert db.GetText(18, strip=True) == "A"
@@ -30,6 +33,7 @@ def test_decode_bits_get_text_strip():
 
 
 def test_decode_bits_get_text_no_strip():
+    """Test DecodeBits.GetText with strip=False preserves padding '@' characters."""
     bv = BitVector.from_bitstring("000001000000000010")
     db = an_util.DecodeBits(bv)
     assert db.GetText(18, strip=False) == "A@B"
@@ -37,12 +41,14 @@ def test_decode_bits_get_text_no_strip():
 
 
 def test_decode_bits_get_text_no_at():
+    """Test DecodeBits.GetText on strings without '@' padding."""
     bv = BitVector.from_bitstring("000001000010")
     db = an_util.DecodeBits(bv)
     assert db.GetText(12, strip=True) == "AB"
 
 
 def test_decode_bits_get_text_unaligned_error():
+    """Test DecodeBits.GetText raises Error when bit length is not 6-bit aligned."""
     bv = BitVector.from_bitstring("00000")
     db = an_util.DecodeBits(bv)
     with pytest.raises(an_util.Error, match="Bits for text must be six bit aligned."):
@@ -50,6 +56,7 @@ def test_decode_bits_get_text_unaligned_error():
 
 
 def test_decode_bits_verify_success():
+    """Test DecodeBits.Verify passes when bit position matches offset."""
     bv = BitVector.from_bitstring("00000000")
     db = an_util.DecodeBits(bv)
     db.GetInt(8)
@@ -57,6 +64,7 @@ def test_decode_bits_verify_success():
 
 
 def test_decode_bits_verify_error():
+    """Test DecodeBits.Verify raises Error when bit position does not match offset."""
     bv = BitVector.from_bitstring("00000000")
     db = an_util.DecodeBits(bv)
     db.GetInt(4)
@@ -65,6 +73,7 @@ def test_decode_bits_verify_error():
 
 
 def test_build_bits_add_uint_add_int_add_text():
+    """Test BuildBits packs unsigned int, signed int, and text into BitVector."""
     bb = an_util.BuildBits()
     bb.AddUInt(5, 4)
     bb.AddInt(-2, 4)
@@ -75,6 +84,7 @@ def test_build_bits_add_uint_add_int_add_text():
 
 
 def test_build_bits_verify_error():
+    """Test BuildBits.Verify raises Error when bit count does not match expected."""
     bb = an_util.BuildBits()
     bb.AddUInt(5, 4)
     with pytest.raises(an_util.Error, match="BuildBits did not verify: 4 != 8"):
@@ -82,6 +92,7 @@ def test_build_bits_verify_error():
 
 
 def test_build_bits_get_bits_mismatch_error():
+    """Test BuildBits.GetBits raises Error when total bits do not match expected."""
     bb = an_util.BuildBits()
     bb.AddUInt(5, 4)
     bb.bits_expected = 8

--- a/tests/binary_test.py
+++ b/tests/binary_test.py
@@ -12,17 +12,20 @@ from ais_area_notice import binary
 
 
 def test_add_one():
+    """Test AddOne increments a BitVector value by 1 with rollover."""
     assert str(binary.AddOne(BitVector.from_bitstring("1100"))) == "1101"
     assert str(binary.AddOne(BitVector.from_bitstring("1111"))) == "0000"
 
 
 def test_sub_one():
+    """Test SubOne decrements a BitVector value by 1 with underflow."""
     assert str(binary.SubOne(BitVector.from_bitstring("1111"))) == "1110"
     assert str(binary.SubOne(BitVector.from_bitstring("0010"))) == "0001"
     assert str(binary.SubOne(BitVector.from_bitstring("0000"))) == "1111"
 
 
 def test_bv_from_signed_int():
+    """Test bvFromSignedInt converts positive and negative integers to BitVector."""
     assert str(binary.bvFromSignedInt(0, bitSize=4)) == "0000"
     assert str(binary.bvFromSignedInt(1, bitSize=4)) == "0001"
     assert str(binary.bvFromSignedInt(7, bitSize=4)) == "0111"
@@ -40,6 +43,7 @@ def test_bv_from_signed_int():
 
 
 def test_signed_int_from_bv():
+    """Test signedIntFromBV decodes BitVector to signed integers."""
     assert binary.signedIntFromBV(BitVector.from_bitstring("0000")) == 0
     assert binary.signedIntFromBV(BitVector.from_bitstring("0101")) == 5
 
@@ -58,6 +62,7 @@ def test_signed_int_from_bv():
 
 
 def test_encode():
+    """Test AIS 6-bit ASCII armoring lookup table entries."""
     assert len(binary.encode) == 64
 
     assert binary.encode[0] == "0"  # 000000
@@ -77,27 +82,32 @@ def test_encode():
 
 
 def test_ais6_to_bitvec():
+    """Test ais6tobitvec converts AIS 6-bit ASCII characters to BitVector."""
     assert str(binary.ais6tobitvec("6")) == "000110"
     assert str(binary.ais6tobitvec("6b")) == "000110101010"
     assert str(binary.ais6tobitvec("6bF:R")) == "000110101010010110001010100010"
 
 
 def test_bitvec_to_ais6():
+    """Test bitvectoais6 converts BitVector to AIS 6-bit ASCII string."""
     assert binary.bitvectoais6(
         BitVector.from_bitstring("000110101010010110001010100010")
     ) == ("6bF:R", 0)
 
 
 def test_bv_from_signed_int_no_bitsize():
+    """Test bvFromSignedInt calculates minimum required bit size automatically."""
     assert str(binary.bvFromSignedInt(5)) == "0101"
     assert str(binary.bvFromSignedInt(-5)) == "1011"
 
 
 def test_bv_from_signed_int_invalid_bitsize():
+    """Test bvFromSignedInt raises ValueError when bitSize is too small."""
     with pytest.raises(ValueError, match="incorrect bit size"):
         binary.bvFromSignedInt(251, bitSize=8)
 
 
 def test_bitvec_to_ais6_no_padding_error():
+    """Test bitvectoais6 raises ValueError when bit length is unaligned and doPadding is False."""
     with pytest.raises(ValueError, match="Results would not be 6-bit aligned."):
         binary.bitvectoais6(BitVector.from_bitstring("101"), doPadding=False)

--- a/tests/imo_001_22_area_notice_test.py
+++ b/tests/imo_001_22_area_notice_test.py
@@ -71,6 +71,7 @@ class TestRegex:
     """Test NMEA sentence regular expression parsing."""
 
     def testWithoutMetadata(self):
+        """Test parsing NMEA sentence without metadata header."""
         msg_str = "!AIVDM,1,1,,A,E>b6Kpiacg`0aagRW:JJropqKLpLkD6D8AB;000000VP20,4*4C"
         match = area_notice.ais_nmea_regex.search(msg_str)
         assert match is not None
@@ -87,6 +88,7 @@ class TestRegex:
         assert result["checksum"] == "4C"
 
     def testWithSimpleMetadata(self):
+        """Test parsing NMEA sentence with simple station and timestamp metadata."""
         msg_str = (
             "!AIVDM,1,1,,B,15N8ac?P00ISgOBA4VU:lOv028Rq,0*4A,b003669953,1297555217"
         )
@@ -107,6 +109,7 @@ class TestRegex:
         assert result["time_stamp"] == "1297555217"
 
     def testWithMetadata(self):
+        """Test parsing NMEA sentence with full receiver metadata."""
         msg_str = (
             # pylint: disable=line-too-long
             "!AIVDM,1,1,,A,15Muq2PP00J64Bf?ktmFpwvl0L0P,0*3F,d-091,S0977,t080226.00,T26.05630183,r07RCED1,1297584148"
@@ -133,6 +136,7 @@ class TestRegex:
         assert result["time_stamp"] == "1297584148"
 
     def testWithX(self):
+        """Test parsing NMEA sentence with extended station metadata fields."""
         msg_str = (
             # pylint: disable=line-too-long
             "!AIVDM,1,1,,B,3018lEU000rA?L@>sp;8L5<>0000,0*26,x367022,s32171,d-079,T08.48347459,r003669976,1166058609"
@@ -158,6 +162,7 @@ class TestRegex:
         assert result["time_stamp"] == "1166058609"
 
     def testMultiLine1(self):
+        """Test parsing first sentence of multi-line NMEA message."""
         msg_str = (
             # pylint: disable=line-too-long
             "!AIVDM,2,1,6,B,54eGK=h00000<O;C?H104<THT>10ThuB1ALt00000000040000000000,0*58,b003669705,1297584166"
@@ -174,6 +179,7 @@ class TestRegex:
         assert result["msg_id"] == "5"
 
     def testMultiLine2(self):
+        """Test parsing second sentence of multi-line NMEA message."""
         msg_str = "!AIVDM,2,2,6,B,000000000000000,2*21,b003669705,1297584166"
         match = area_notice.ais_nmea_regex.search(msg_str)
         assert match is not None
@@ -186,6 +192,7 @@ class TestRegex:
         assert result["chan"] == "B"
 
     def testOwnShip(self):
+        """Test parsing AIVDO own-ship sentence."""
         msg_str = "!AIVDO,1,1,,,13tfD@?P7BJsWhhHb5eBtwwL0000,0*05,rnhjel,1297555200.32"
         match = area_notice.ais_nmea_regex.search(msg_str)
         assert match is not None
@@ -203,6 +210,7 @@ class Test0Math:
     """Test vector rotation math helpers."""
 
     def testRotate(self):
+        """Test rotating origin point vector."""
         # Rotate about 0.
         p1 = (0, 0)
         assert (0, 0) == area_notice.vec_rot(p1, 0)
@@ -212,6 +220,7 @@ class Test0Math:
         assert (0, 0) == area_notice.vec_rot(p1, -math.pi / 4)
 
     def testRotate2(self):
+        """Test rotating unit X vector by various angles."""
         # Rotate of 1, 0.
         p1 = (1, 0)
         assert (1, 0) == area_notice.vec_rot(p1, 0)
@@ -234,6 +243,7 @@ class Test0Math:
         )
 
     def testRotate3(self):
+        """Test rotating unit Y vector by various angles."""
         # Rotate of 0, 1.
         p1 = (0, 1)
         assert (0, 1) == area_notice.vec_rot(p1, 0)
@@ -257,6 +267,7 @@ class Test1AIVDM:
     """Test AIVDM sentence generator base class."""
 
     def testAivdm(self):
+        """Test AIVDM sentence generator raises exception when mandatory fields missing."""
         a = area_notice.AIVDM()
         with pytest.raises(area_notice.AisPackingException):
             a.get_aivdm(sequence_num=0, channel="A", source_mmsi=123456789)
@@ -275,6 +286,7 @@ class Test3AreaNoticeCirclePt:
     """Test circle/point subarea geometry and bit packing."""
 
     def testCircleGeom(self):
+        """Test point and circle Shapely geometry generation."""
         pt1 = area_notice.AreaNoticeCirclePt(-73, 43, 0)
         assert pt1.radius == 0
         assert_almost_equal_series((-73, 43), list(pt1.geom().coords)[0])
@@ -284,6 +296,7 @@ class Test3AreaNoticeCirclePt:
         assert len(pt2.geom().boundary.coords) > 10
 
     def testSelfConsistant(self):
+        """Test AreaNoticeCirclePt bit packing and unpacking round-trip consistency."""
         pt0 = area_notice.AreaNoticeCirclePt(-73, 43, 0)
         pt1 = area_notice.AreaNoticeCirclePt(bits=pt0.get_bits())
         assert pt1.lon == pytest.approx(-73)
@@ -302,6 +315,7 @@ class Test5AreaNoticeSimple:
     """Test simple Area Notice message encoding and visualization."""
 
     def testSimple(self):
+        """Test basic Area Notice bitstream generation with options."""
         an1 = area_notice.AreaNotice(0, datetime.datetime.utcnow(), 100)
         assert len(an1.get_bits()) == 2 + 16 + 10 + 7 + 4 + 5 + 5 + 6 + 18
         assert len(an1.get_bits(include_dac_fi=False)) == 10 + 7 + 4 + 5 + 5 + 6 + 18
@@ -321,6 +335,7 @@ class Test5AreaNoticeSimple:
         assert len(an1.get_bbm()) == 1
 
     def testWhale(self):
+        """Test building Area Notice for whale safety subareas."""
         no_whales = area_notice.AreaNotice(
             area_notice.notice_type["cau_mammals_not_obs"],
             datetime.datetime.utcnow(),
@@ -335,6 +350,7 @@ class Test5AreaNoticeSimple:
         no_whales.add_subarea(area_notice.AreaNoticeCirclePt(-68, 43, radius=9260))
 
     def testCircleSubareaJson(self):
+        """Test GeoJSON export for circle and point subareas."""
         area = area_notice.AreaNoticeCirclePt(-69.849541, 42.0792730, radius=9260)
         assert len(area.__geo_interface__["geometry"]["coordinates"]) > 5
 
@@ -342,6 +358,7 @@ class Test5AreaNoticeSimple:
         assert len(area.__geo_interface__["geometry"]["coordinates"]) == 2
 
     def testHtml(self):
+        """Test HTML rendering of Area Notice."""
         whales = area_notice.AreaNotice(
             area_notice.notice_type["cau_mammals_reduce_speed"],
             datetime.datetime.utcnow(),
@@ -355,6 +372,7 @@ class Test5AreaNoticeSimple:
         # TODO(schwehr): Write the test.
 
     def testKml(self):
+        """Test KML markup generation for Area Notice."""
         whales = area_notice.AreaNotice(
             area_notice.notice_type["cau_mammals_reduce_speed"],
             datetime.datetime.utcnow(),
@@ -375,6 +393,7 @@ class TestBitDecoding:
     """Test Area Notice bit decoding for point subareas."""
 
     def testPoint(self):
+        """Test Area Notice encoding and decoding roundtrip for point subarea."""
         year = datetime.datetime.utcnow().year
         pt1 = area_notice.AreaNotice(
             area_notice.notice_type["cau_mammals_not_obs"],
@@ -397,6 +416,7 @@ class TestBitDecoding:
         assert_almost_equal_geojson(orig, decoded)
 
     def testCircle(self):
+        """Test Area Notice encoding and decoding roundtrip for circle subarea."""
         now = datetime.datetime.utcnow()
         circle1 = area_notice.AreaNotice(
             area_notice.notice_type["cau_mammals_reduce_speed"],
@@ -417,6 +437,7 @@ class TestBitDecoding:
         assert_almost_equal_geojson(orig, decoded)
 
     def testRectangle(self):
+        """Test Area Notice encoding and decoding roundtrip for rectangle subarea."""
         rect = area_notice.AreaNotice(
             area_notice.notice_type["cau_mammals_reduce_speed"],
             datetime.datetime(datetime.datetime.utcnow().year, 7, 6, 0, 0, 4),
@@ -435,6 +456,7 @@ class TestBitDecoding:
         assert_almost_equal_geojson(orig, decoded)
 
     def testSector(self):
+        """Test Area Notice encoding and decoding roundtrip for sector subarea."""
         sec1 = area_notice.AreaNotice(
             area_notice.notice_type["cau_habitat_reduce_speed"],
             datetime.datetime(datetime.datetime.utcnow().year, 7, 6, 0, 0, 4),
@@ -452,6 +474,7 @@ class TestBitDecoding:
         assert_almost_equal_geojson(orig, decoded)
 
     def testLine(self):
+        """Test Area Notice encoding and decoding roundtrip for polyline subarea."""
         line1 = area_notice.AreaNotice(
             area_notice.notice_type["report_of_icing"],
             datetime.datetime(datetime.datetime.utcnow().year, 7, 6, 0, 0, 4),
@@ -468,6 +491,7 @@ class TestBitDecoding:
         assert_almost_equal_geojson(orig, decoded)
 
     def testPolygon(self):
+        """Test Area Notice encoding and decoding roundtrip for polygon subarea."""
         poly1 = area_notice.AreaNotice(
             area_notice.notice_type["cau_divers"],
             datetime.datetime(datetime.datetime.utcnow().year, 7, 6, 0, 0, 4),
@@ -486,6 +510,7 @@ class TestBitDecoding:
         assert_almost_equal_geojson(orig, decoded)
 
     def testFreeText(self):
+        """Test Area Notice encoding and decoding roundtrip for free text subarea."""
         text1 = area_notice.AreaNotice(
             area_notice.notice_type["res_military_ops"],
             datetime.datetime(datetime.datetime.utcnow().year, 7, 6, 0, 4, 0),
@@ -509,6 +534,7 @@ class TestBitDecoding2:
     """Test Area Notice bit decoding for complex mixed subareas."""
 
     def testPoint(self):
+        """Test Area Notice with one subarea of every shape type."""
         # One of each.
         notice = area_notice.AreaNotice(
             area_notice.notice_type["cau_mammals_not_obs"],
@@ -539,6 +565,7 @@ class TestBitDecoding2:
         assert_almost_equal_geojson(orig, decoded)
 
     def testManySectors(self):
+        """Test Area Notice with multiple sector subareas and max subarea limit."""
         notice = area_notice.AreaNotice(
             area_notice.notice_type["cau_mammals_not_obs"],
             datetime.datetime(datetime.datetime.utcnow().year, 7, 6, 0, 0, 4),
@@ -589,6 +616,7 @@ class TestBitDecoding2:
             )
 
     def testFullText(self):
+        """Test Area Notice with multi-part text subareas and merged text retrieval."""
         notice = area_notice.AreaNotice(
             area_notice.notice_type["cau_mammals_not_obs"],
             datetime.datetime(datetime.datetime.utcnow().year, 7, 6, 0, 0, 4),
@@ -630,6 +658,7 @@ class TestLineTools:
 
     @pytest.mark.skip(reason="TODO(schwehr): Fix this failure.")
     def testOneSegmentCardinal(self):
+        """Test converting lon/lat segments to polyline angle and distance offsets."""
         p0 = (0, 0)
 
         deg_1_meters = 111120
@@ -660,6 +689,7 @@ class TestWhaleNotices:
     """Make sure the whale notices works correctly."""
 
     def testNoWhales(self):
+        """Test Area Notice for cautionary no whales observed zone."""
         zone_type = area_notice.notice_type["cau_mammals_not_obs"]
         circle = area_notice.AreaNotice(
             zone_type,
@@ -695,6 +725,7 @@ class TestWhaleNotices:
         # TODO(schwehr): Verify other parameters like the location and times.
 
     def testWhalesObservedCircleNotice(self):
+        """Test Area Notice for mandatory whale speed reduction circle zone."""
         zone_type = area_notice.notice_type["cau_mammals_reduce_speed"]
         circle = area_notice.AreaNotice(
             zone_type,
@@ -730,17 +761,20 @@ class TestWhaleNotices:
 
 
 def test_ll_to_polyline_and_helpers():
+    """Test converting lon/lat coordinates to polyline angle and distance offsets."""
     ll_points = [(-122.0, 37.0), (-122.1, 37.1), (-122.2, 37.2)]
     offsets = area_notice.ll_to_polyline(ll_points)
     assert len(offsets) == 2
 
 
 def test_frange_defaults():
+    """Test floating point range generator defaults."""
     r1 = list(area_notice.frange(5))
     assert r1 == [0.0, 1.0, 2.0, 3.0, 4.0]
 
 
 def test_geom2kml_linestring_and_invalid():
+    """Test GeoJSON geometry to KML conversion."""
     ls_geom = {
         "geometry": {
             "type": "LineString",
@@ -756,12 +790,14 @@ def test_geom2kml_linestring_and_invalid():
 
 
 def test_ais_exception_repr():
+    """Test string representation of AisException instances."""
     exc = area_notice.AisException("test error")
     assert repr(exc) == "test error"
     assert str(exc) == "test error"
 
 
 def test_get_bits_header_errors_and_override(monkeypatch):
+    """Test AIVDM header bit generation and validation error handling."""
     aivdm = area_notice.AIVDM(message_id=8, repeat_indicator=0, source_mmsi=123456789)
     bv = aivdm.get_bits_header(source_mmsi=987654321)
     assert len(bv) == 38
@@ -774,6 +810,7 @@ def test_get_bits_header_errors_and_override(monkeypatch):
 
 
 def test_get_aivdm_validation_errors():
+    """Test get_aivdm parameter validation and exception handling."""
     aivdm = area_notice.AIVDM(message_id=8, repeat_indicator=0, source_mmsi=123456789)
     with pytest.raises(area_notice.AisPackingException, match="sequence_num 10"):
         aivdm.get_aivdm(sequence_num=10)
@@ -786,6 +823,7 @@ def test_get_aivdm_validation_errors():
 
 
 def test_get_aivdm_byte_align_and_normal_form_and_sequence_wrap():
+    """Test AIVDM byte alignment, normal form, and sequence number wrap-around."""
     when = datetime.datetime(2026, 8, 7, 0, 0, 0)
     an = area_notice.AreaNotice(
         area_type=1, when=when, duration=60, source_mmsi=123456789
@@ -812,6 +850,7 @@ def test_get_aivdm_byte_align_and_normal_form_and_sequence_wrap():
 
 
 def test_aivdm_header_none_mmsi():
+    """Test get_bits_header raises exception when MMSI is None."""
     aivdm = area_notice.AIVDM(message_id=8, repeat_indicator=0)
     with pytest.raises(
         area_notice.AisPackingException, match="source_mmsi must be valid"
@@ -820,6 +859,8 @@ def test_aivdm_header_none_mmsi():
 
 
 def test_aivdm_get_aivdm_byte_aligned_okay(capsys):
+    """Test get_aivdm logs byte alignment status when payload is already byte-aligned."""
+
     class MockAIVDM(area_notice.AIVDM):
         """Mock AIVDM subclass for testing byte alignment logging."""
 
@@ -833,6 +874,7 @@ def test_aivdm_get_aivdm_byte_aligned_okay(capsys):
 
 
 def test_area_notice_kml_options(monkeypatch, tmp_path):
+    """Test KML generation options, styles, and empty geometry handling."""
     when = datetime.datetime(2026, 8, 7, 0, 0)
     an = area_notice.AreaNotice(
         area_type=1, when=when, duration=60, source_mmsi=123456789
@@ -872,6 +914,7 @@ def test_area_notice_kml_options(monkeypatch, tmp_path):
 
 
 def test_bbm_errors_and_multisentence():
+    """Test BBM validation errors and multi-sentence NMEA payload generation."""
     bbm = area_notice.BBM(message_id=8)
     with pytest.raises(area_notice.AisPackingException, match="talker"):
         bbm.get_bbm(talker="INVALID")
@@ -892,6 +935,7 @@ def test_bbm_errors_and_multisentence():
 
 
 def test_circle_pt_scale_factors_and_decoding():
+    """Test AreaNoticeCirclePt scale factor calculation and bit decoding."""
     c3 = area_notice.AreaNoticeCirclePt(-122.0, 37.0, radius=409500)
     assert c3.scale_factor_raw == 3
     assert c3.scale_factor == 1000
@@ -931,6 +975,7 @@ def test_circle_pt_scale_factors_and_decoding():
 
 
 def test_rectangle_scale_factors_decoding_unicode():
+    """Test AreaNoticeRectangle scale factor calculation and string representation."""
     with pytest.raises(AssertionError):
         area_notice.AreaNoticeRectangle(-122.0, 37.0, east_dim=255000)
 
@@ -957,6 +1002,7 @@ def test_rectangle_scale_factors_decoding_unicode():
 
 
 def test_sector_scale_factors_decoding_unicode():
+    """Test AreaNoticeSector scale factor calculation and decoding."""
     sec3 = area_notice.AreaNoticeSector(
         -122.0, 37.0, radius=409500, left_bound_deg=0, right_bound_deg=90
     )
@@ -989,6 +1035,7 @@ def test_sector_scale_factors_decoding_unicode():
 
 
 def test_polyline_scale_factors_decoding_errors_unicode(capsys):
+    """Test AreaNoticePolyline scale factor calculation, bit encoding limits, and error logging."""
     p2 = area_notice.AreaNoticePolyline(lon=-122.0, lat=37.0, points=[(45, 20000)])
     assert p2.scale_factor_raw == 2
 
@@ -1070,6 +1117,7 @@ def test_polyline_scale_factors_decoding_errors_unicode(capsys):
 
 
 def test_polygon_unicode_and_freetext_methods():
+    """Test AreaNoticePolygon and AreaNoticeFreeText string representation and decoding."""
     poly = area_notice.AreaNoticePolygon(
         lon=-122.0, lat=37.0, points=[(45, 100), (90, 100)]
     )
@@ -1104,6 +1152,7 @@ def test_polygon_unicode_and_freetext_methods():
 
 
 def test_area_notice_init_and_methods_and_errors():
+    """Test AreaNotice initialization, HTML/GeoJSON export, and subarea count limits."""
     with pytest.raises(AssertionError):
         area_notice.AreaNotice()
 
@@ -1185,6 +1234,7 @@ def test_area_notice_init_and_methods_and_errors():
 
 
 def test_area_notice_decode_nmea_errors():
+    """Test AreaNotice NMEA sentence decoding error handling."""
     when = datetime.datetime(2026, 8, 7, 0, 0)
     an = area_notice.AreaNotice(
         area_type=1, when=when, duration=60, source_mmsi=123456789
@@ -1202,6 +1252,7 @@ def test_area_notice_decode_nmea_errors():
 
 
 def test_subarea_factory_and_get_shapes():
+    """Test subarea factory shape instantiation and sequencing validation."""
     when = datetime.datetime(2026, 8, 7, 0, 0)
     an = area_notice.AreaNotice(
         area_type=1, when=when, duration=60, source_mmsi=123456789
@@ -1242,6 +1293,7 @@ def test_subarea_factory_and_get_shapes():
 
 
 def test_message_2_fetcherformatter_and_normqueue():
+    """Test CSV message formatting and NormQueue multi-sentence NMEA reassembly."""
     when = datetime.datetime(2026, 8, 7, 0, 0)
     an = area_notice.AreaNotice(
         area_type=1, when=when, duration=60, source_mmsi=123456789
@@ -1297,6 +1349,7 @@ def test_message_2_fetcherformatter_and_normqueue():
 
 
 def test_main_cli(monkeypatch, tmp_path):
+    """Test CLI main entry point sentence parsing and KML output file creation."""
     when = datetime.datetime(2026, 8, 7, 0, 0)
     an = area_notice.AreaNotice(
         area_type=1, when=when, duration=60, source_mmsi=123456789

--- a/tests/imo_001_22_area_notice_test.py
+++ b/tests/imo_001_22_area_notice_test.py
@@ -945,7 +945,7 @@ def test_circle_pt_scale_factors_and_decoding():
     cd_tuple = area_notice.AreaNoticeCirclePt(bits=bits_tuple)
     assert cd_tuple.radius == pytest.approx(c1.radius, abs=1000)
 
-    def mock_join_short(bv_list):
+    def mock_join_short(_bv_list):
         return BitVector(size=50)
 
     with pytest.raises(area_notice.AisPackingException, match="area not 87 bits"):
@@ -1120,7 +1120,7 @@ def test_polygon_unicode_and_freetext_methods():
     ft_tup = area_notice.AreaNoticeFreeText(bits=bv_tup)
     assert ft_tup.text == "TEST"
 
-    def mock_join_short(bv_list):
+    def mock_join_short(_bv_list):
         return BitVector(size=50)
 
     with pytest.raises(

--- a/tests/imo_001_22_area_notice_test.py
+++ b/tests/imo_001_22_area_notice_test.py
@@ -405,9 +405,7 @@ class TestBitDecoding:
         pt1.add_subarea(area_notice.AreaNoticeCirclePt(-69.8, 42.0, radius=0))
         orig = geojson.loads(geojson.dumps(pt1))
 
-        decoded_pt = area_notice.AreaNotice(
-            nmea_strings=[line for line in pt1.get_aivdm()]
-        )
+        decoded_pt = area_notice.AreaNotice(nmea_strings=list(pt1.get_aivdm()))
 
         decoded = geojson.loads(geojson.dumps(decoded_pt))
 
@@ -429,7 +427,7 @@ class TestBitDecoding:
         circle1.add_subarea(area_notice.AreaNoticeCirclePt(-69.8, 42.1, radius=4260))
 
         orig = geojson.loads(geojson.dumps(circle1))
-        nmea_strings = [line for line in circle1.get_aivdm()]
+        nmea_strings = list(circle1.get_aivdm())
         decoded = geojson.loads(
             geojson.dumps(area_notice.AreaNotice(nmea_strings=nmea_strings))
         )
@@ -449,9 +447,7 @@ class TestBitDecoding:
 
         orig = geojson.loads(geojson.dumps(rect))
         decoded = geojson.loads(
-            geojson.dumps(
-                area_notice.AreaNotice(nmea_strings=[line for line in rect.get_aivdm()])
-            )
+            geojson.dumps(area_notice.AreaNotice(nmea_strings=list(rect.get_aivdm())))
         )
         assert_almost_equal_geojson(orig, decoded)
 
@@ -467,9 +463,7 @@ class TestBitDecoding:
         sec1.add_subarea(area_notice.AreaNoticeSector(-69.8, 42.3, 4000, 10, 50))
         orig = geojson.loads(geojson.dumps(sec1))
         decoded = geojson.loads(
-            geojson.dumps(
-                area_notice.AreaNotice(nmea_strings=[line for line in sec1.get_aivdm()])
-            )
+            geojson.dumps(area_notice.AreaNotice(nmea_strings=list(sec1.get_aivdm())))
         )
         assert_almost_equal_geojson(orig, decoded)
 
@@ -484,9 +478,7 @@ class TestBitDecoding:
         )
         line1.add_subarea(area_notice.AreaNoticePolyline([(10, 2400)], -69.8, 42.4))
         orig = geojson.loads(geojson.dumps(line1))
-        line2 = area_notice.AreaNotice(
-            nmea_strings=[line for line in line1.get_aivdm()]
-        )
+        line2 = area_notice.AreaNotice(nmea_strings=list(line1.get_aivdm()))
         decoded = geojson.loads(geojson.dumps(line2))
         assert_almost_equal_geojson(orig, decoded)
 
@@ -503,9 +495,7 @@ class TestBitDecoding:
             area_notice.AreaNoticePolygon([(10, 1400), (90, 1950)], -69.8, 42.5)
         )
         orig = geojson.loads(geojson.dumps(poly1))
-        poly2 = area_notice.AreaNotice(
-            nmea_strings=[line for line in poly1.get_aivdm()]
-        )
+        poly2 = area_notice.AreaNotice(nmea_strings=list(poly1.get_aivdm()))
         decoded = geojson.loads(geojson.dumps(poly2))
         assert_almost_equal_geojson(orig, decoded)
 
@@ -522,9 +512,7 @@ class TestBitDecoding:
         text1.add_subarea(area_notice.AreaNoticeFreeText(text="Explanation"))
 
         orig = geojson.loads(geojson.dumps(text1))
-        text2 = area_notice.AreaNotice(
-            nmea_strings=[line for line in text1.get_aivdm()]
-        )
+        text2 = area_notice.AreaNotice(nmea_strings=list(text1.get_aivdm()))
         decoded = geojson.loads(geojson.dumps(text2))
 
         assert_almost_equal_geojson(orig, decoded)
@@ -558,7 +546,7 @@ class TestBitDecoding2:
         notice.add_subarea(area_notice.AreaNoticeFreeText(text="Some Text"))
 
         orig = geojson.loads(geojson.dumps(notice))
-        nmea_strings = [line for line in notice.get_aivdm()]
+        nmea_strings = list(notice.get_aivdm())
         decoded = geojson.loads(
             geojson.dumps(area_notice.AreaNotice(nmea_strings=nmea_strings))
         )
@@ -590,11 +578,7 @@ class TestBitDecoding2:
 
         orig = geojson.loads(geojson.dumps(notice))
         decoded = geojson.loads(
-            geojson.dumps(
-                area_notice.AreaNotice(
-                    nmea_strings=[line for line in notice.get_aivdm()]
-                )
-            )
+            geojson.dumps(area_notice.AreaNotice(nmea_strings=list(notice.get_aivdm())))
         )
         assert_almost_equal_geojson(orig, decoded)
 
@@ -644,11 +628,7 @@ class TestBitDecoding2:
 
         orig = geojson.loads(geojson.dumps(notice))
         decoded = geojson.loads(
-            geojson.dumps(
-                area_notice.AreaNotice(
-                    nmea_strings=[line for line in notice.get_aivdm()]
-                )
-            )
+            geojson.dumps(area_notice.AreaNotice(nmea_strings=list(notice.get_aivdm())))
         )
         assert_almost_equal_geojson(orig, decoded)
 

--- a/tests/imo_001_26_environment_test.py
+++ b/tests/imo_001_26_environment_test.py
@@ -1540,7 +1540,7 @@ class TestEnvironment:
             def __init__(self):
                 self.calls = 0
 
-            def search(self, text):
+            def search(self, _text):
                 """Simulate regex search calls returning fake matches."""
                 self.calls += 1
                 if self.calls == 1:

--- a/tests/imo_001_26_environment_test.py
+++ b/tests/imo_001_26_environment_test.py
@@ -20,6 +20,11 @@ FUZZ_COUNT = 30
 
 
 def random_date():
+    """Generate a random datetime within 2010-2049.
+
+    Returns:
+        A randomized datetime instance.
+    """
     year = random.randint(2010, 2049)
     j_day = random.randint(1, 355)
     hour = random.randint(0, 23)
@@ -29,6 +34,11 @@ def random_date():
 
 
 def random_loc():
+    """Generate a randomized SensorReportLocation instance.
+
+    Returns:
+        A randomized SensorReportLocation object.
+    """
     date = random_date()
     lon = random.randrange(-1800000, 1800000) / 10000.0
     lat = random.randrange(-900000, 900000) / 10000.0
@@ -52,6 +62,11 @@ def random_loc():
 
 
 def random_id():
+    """Generate a randomized SensorReportId instance.
+
+    Returns:
+        A randomized SensorReportId object.
+    """
     date = random_date()
     site_id = random.randint(0, 127)
     msg_len = random.randint(0, 14)
@@ -69,6 +84,11 @@ def random_id():
 
 
 def random_wind():
+    """Generate a randomized SensorReportWind instance.
+
+    Returns:
+        A randomized SensorReportWind object.
+    """
     date = random_date()
     site_id = random.randint(0, 127)
     data_descr = random.choice(list(env.sensor_type_lut.keys()))
@@ -95,6 +115,11 @@ def random_wind():
 
 
 def random_waterlevel():
+    """Generate a randomized SensorReportWaterLevel instance.
+
+    Returns:
+        A randomized SensorReportWaterLevel object.
+    """
     date = random_date()
     site_id = random.randint(0, 127)
 
@@ -123,6 +148,11 @@ def random_waterlevel():
 
 
 def random_current2d():
+    """Generate a randomized SensorReportCurrent2d instance.
+
+    Returns:
+        A randomized SensorReportCurrent2d object.
+    """
     date = random_date()
     site_id = random.randint(0, 127)
 
@@ -150,6 +180,11 @@ def random_current2d():
 
 
 def random_current3d():
+    """Generate a randomized SensorReportCurrent3d instance.
+
+    Returns:
+        A randomized SensorReportCurrent3d object.
+    """
     date = random_date()
     site_id = random.randint(0, 127)
     return env.SensorReportCurrent3d(
@@ -172,6 +207,11 @@ def random_current3d():
 
 
 def random_currenthorz():
+    """Generate a randomized SensorReportCurrentHorz instance.
+
+    Returns:
+        A randomized SensorReportCurrentHorz object.
+    """
     date = random_date()
     site_id = random.randint(0, 127)
     return env.SensorReportCurrentHorz(
@@ -195,6 +235,11 @@ def random_currenthorz():
 
 
 def random_seastate():
+    """Generate a randomized SensorReportSeaState instance.
+
+    Returns:
+        A randomized SensorReportSeaState object.
+    """
     date = random_date()
     site_id = random.randint(0, 127)
     return env.SensorReportSeaState(
@@ -221,6 +266,11 @@ def random_seastate():
 
 
 def random_salinity():
+    """Generate a randomized SensorReportSalinity instance.
+
+    Returns:
+        A randomized SensorReportSalinity object.
+    """
     date = random_date()
     site_id = random.randint(0, 127)
     return env.SensorReportSalinity(
@@ -240,6 +290,11 @@ def random_salinity():
 
 
 def random_weather():
+    """Generate a randomized SensorReportWeather instance.
+
+    Returns:
+        A randomized SensorReportWeather object.
+    """
     date = random_date()
     site_id = random.randint(0, 127)
     return env.SensorReportWeather(
@@ -263,6 +318,11 @@ def random_weather():
 
 
 def random_airgap():
+    """Generate a randomized SensorReportAirGap instance.
+
+    Returns:
+        A randomized SensorReportAirGap object.
+    """
     date = random_date()
     site_id = random.randint(0, 127)
     return env.SensorReportAirGap(
@@ -306,6 +366,7 @@ class TestSensorReports:
     """Test suite for sensor report classes and bitstream packing/unpacking."""
 
     def setup_method(self):
+        """Set up current timestamp for test instances."""
         now = datetime.datetime.utcnow()
         self.year = now.year
         self.month = now.month
@@ -314,6 +375,7 @@ class TestSensorReports:
         self.minute = now.minute
 
     def test_SensorReport(self):
+        """Test base SensorReport initialization, header bit length, and date calculation."""
         # Create and work with just the parent class.
         report_type = 0
         site_id = 0
@@ -383,6 +445,7 @@ class TestSensorReports:
         assert sr_0 != sr_1
 
     def test_Sr_not_eq(self):
+        """Test SensorReport inequality for differing site IDs."""
         sr_0 = env.SensorReport(0, 2010, 1, 1, 1, 1, site_id=0)
         sr_1 = env.SensorReport(0, 2010, 1, 1, 1, 1, site_id=1)
         assert sr_0 != sr_1
@@ -444,6 +507,7 @@ class TestSensorReports:
         assert sr_l == sr_lb
 
     def test_SrLoc_fuzz(self):
+        """Fuzz test SensorReportLocation bit stream roundtrip."""
         for _ in range(FUZZ_COUNT):
             sr = random_loc()
             sr_b = env.SensorReportLocation(bits=sr.get_bits())
@@ -473,6 +537,7 @@ class TestSensorReports:
         assert s1 == s2
 
     def test_SrId_fuzz(self):
+        """Fuzz test SensorReportId bit stream roundtrip."""
         for _ in range(FUZZ_COUNT):
             sr = random_id()
             sr_b = env.SensorReportId(bits=sr.get_bits())
@@ -591,6 +656,7 @@ class TestSensorReports:
         assert sr_b.duration_min == 255
 
     def test_SrWind_fuzz(self):
+        """Fuzz test SensorReportWind bit stream roundtrip."""
         for _ in range(FUZZ_COUNT):
             sr = random_wind()
             sr_b = env.SensorReportWind(bits=sr.get_bits())
@@ -695,6 +761,7 @@ class TestSensorReports:
         assert sr_b.duration_min == 255
 
     def test_SrWaterLevel_fuzz(self):
+        """Fuzz test SensorReportWaterLevel bit stream roundtrip."""
         for _ in range(FUZZ_COUNT):
             sr = random_waterlevel()
             sr_b = env.SensorReportWaterLevel(bits=sr.get_bits())
@@ -777,6 +844,7 @@ class TestSensorReports:
         assert sr_b.data_descr == 5
 
     def test_SrCurrent2d_fuzz(self):
+        """Fuzz test SensorReportCurrent2d bit stream roundtrip."""
         for _ in range(FUZZ_COUNT):
             sr = random_current2d()
             sr_b = env.SensorReportCurrent2d(bits=sr.get_bits())
@@ -851,6 +919,7 @@ class TestSensorReports:
         assert sr_b.data_descr == 0
 
     def test_SrCurrent3d_fuzz(self):
+        """Fuzz test SensorReportCurrent3d bit stream roundtrip."""
         for _ in range(FUZZ_COUNT):
             sr = random_current3d()
             sr_b = env.SensorReportCurrent3d(bits=sr.get_bits())
@@ -926,6 +995,7 @@ class TestSensorReports:
             assert cur["level"] == 361
 
     def test_SrCurrentHorz_fuzz(self):
+        """Fuzz test SensorReportCurrentHorz bit stream roundtrip."""
         for _ in range(FUZZ_COUNT):
             sr = random_currenthorz()
             sr_b = env.SensorReportCurrentHorz(bits=sr.get_bits())
@@ -1022,6 +1092,7 @@ class TestSensorReports:
         assert sr_b.salinity == pytest.approx(50.0)
 
     def test_SrCurrentSeaState_fuzz(self):
+        """Fuzz test SensorReportSeaState bit stream roundtrip."""
         for _ in range(FUZZ_COUNT):
             sr = random_seastate()
             sr_b = env.SensorReportSeaState(bits=sr.get_bits())
@@ -1089,6 +1160,7 @@ class TestSensorReports:
         assert sr_b.data_descr == 5
 
     def test_SrCurrentSalinity_fuzz(self):
+        """Fuzz test SensorReportSalinity bit stream roundtrip."""
         for _ in range(FUZZ_COUNT):
             sr = random_salinity()
             sr_b = env.SensorReportSalinity(bits=sr.get_bits())
@@ -1172,6 +1244,7 @@ class TestSensorReports:
         assert sr_b.salinity == pytest.approx(50.0)
 
     def test_SrWeather_fuzz(self):
+        """Fuzz test SensorReportWeather bit stream roundtrip."""
         for _ in range(FUZZ_COUNT):
             sr = random_weather()
             sr_b = env.SensorReportWeather(bits=sr.get_bits())
@@ -1243,6 +1316,7 @@ class TestSensorReports:
         assert sr_b.forecast_minute == 59
 
     def test_SrAirGap_fuzz(self):
+        """Fuzz test SensorReportAirGap bit stream roundtrip."""
         for _ in range(FUZZ_COUNT):
             sr = random_airgap()
             sr_b = env.SensorReportAirGap(bits=sr.get_bits())
@@ -1257,6 +1331,7 @@ class TestEnvironment:
     """Environmental Message with a variety of SensorReports"""
 
     def setup_method(self):
+        """Set up current timestamp for environment test instances."""
         now = datetime.datetime.utcnow()
         self.year = now.year
         self.month = now.month
@@ -1265,6 +1340,7 @@ class TestEnvironment:
         self.minute = now.minute
 
     def test_empty(self):
+        """Test empty Environment message serialization, string representation, and comparison."""
         e = env.Environment(source_mmsi=123456)
         assert e == e  # pylint: disable=comparison-with-itself
         assert len(e.sensor_reports) == 0
@@ -1280,6 +1356,7 @@ class TestEnvironment:
         assert e != e_b
 
     def test_single(self):
+        """Test Environment with single sensor report for all report types."""
         e_instances = []
         for sr_class in env.sensor_report_classes:
             e = env.Environment(source_mmsi=123456)
@@ -1305,6 +1382,7 @@ class TestEnvironment:
                 assert msg != other_msg
 
     def test_wind(self):
+        """Test Environment with SensorReportWind sub-report decoding."""
         e = env.Environment(source_mmsi=656565)
 
         sr = env.SensorReportWind(
@@ -1358,6 +1436,7 @@ class TestEnvironment:
             assert e == e_b
 
     def test_two(self):
+        """Test Environment with multiple randomized sensor reports."""
         for _ in range(FUZZ_COUNT // 2):
             e = env.Environment(source_mmsi=random.randint(100000, 999999999))
             sr1 = random_sensorreport()
@@ -1396,6 +1475,7 @@ class TestEnvironment:
             assert sr == sb_b
 
     def test_add_sensor_report_no_attr_and_too_many(self):
+        """Test adding sensor reports handles missing attribute and max limit."""
         e = env.Environment(source_mmsi=123456)
         del e.sensor_reports
         sr = env.SensorReportId(site_id=1)
@@ -1411,12 +1491,14 @@ class TestEnvironment:
             e.add_sensor_report(sr)
 
     def test_get_report_types(self):
+        """Test retrieving list of report type IDs in Environment."""
         e = env.Environment(source_mmsi=123456)
         e.add_sensor_report(env.SensorReportLocation(site_id=1))
         e.add_sensor_report(env.SensorReportWind(site_id=2))
         assert e.get_report_types() == [0, 2]
 
     def test_get_bits_no_mmsi_and_too_large(self):
+        """Test get_bits error handling for missing MMSI and oversized payload."""
         e = env.Environment(source_mmsi=123456)
         e.source_mmsi = None
         with pytest.raises(env.AisPackingException, match="No mmsi specified."):
@@ -1430,6 +1512,7 @@ class TestEnvironment:
             e2.get_bits()
 
     def test_decode_nmea_errors(self, monkeypatch):
+        """Test NMEA decoding error handling for Environment."""
         e = env.Environment(source_mmsi=123456)
         with pytest.raises(env.AisUnpackingException, match="Checksum failed"):
             e.decode_nmea(["!AIVDM,1,1,0,A,85M:Ih1KmPAU6jAs85`03cJm;1NHQhPFP000,0*99"])
@@ -1441,12 +1524,14 @@ class TestEnvironment:
             """Fake NMEA regex match with checksum."""
 
             def groupdict(self):
+                """Return groupdict with valid checksum."""
                 return {"checksum": "19"}
 
         class FakeMatch2:
             """Fake NMEA regex match with no groupdict."""
 
             def groupdict(self):
+                """Return None for groupdict."""
                 return None
 
         class FakeRegex:
@@ -1456,6 +1541,7 @@ class TestEnvironment:
                 self.calls = 0
 
             def search(self, text):
+                """Simulate regex search calls returning fake matches."""
                 self.calls += 1
                 if self.calls == 1:
                     return FakeMatch1()
@@ -1466,6 +1552,7 @@ class TestEnvironment:
             e.decode_nmea(["!AIVDM,1,1,0,A,85M:Ih1KmPAU6jAs85`03cJm;1NHQhPFP000,0*19"])
 
     def test_decode_bits_fill_bits_trouble(self):
+        """Test decoding invalid BitVector size raises exception."""
         e = env.Environment(source_mmsi=123456)
 
         invalid_bits = BitVector(size=56 + 112 + 10)
@@ -1475,6 +1562,7 @@ class TestEnvironment:
             e.decode_bits(invalid_bits)
 
     def test_sensor_report_factory_reserved_type(self):
+        """Test sensor report factory raises exception for reserved type IDs."""
         e = env.Environment(source_mmsi=123456)
 
         reserved_bits = BitVector.from_bitstring("1011" + "0" * 108)
@@ -1485,11 +1573,13 @@ class TestEnvironment:
             e.sensor_report_factory(reserved_bits)
 
     def test_geo_interface(self):
+        """Test unimplemented __geo_interface__ property raises exception."""
         e = env.Environment(source_mmsi=123456)
         with pytest.raises(NotImplementedError):
             _ = e.__geo_interface__
 
     def test_air_gap_decode_bits_size_and_get_bits_size(self, monkeypatch):
+        """Test SensorReportAirGap size validation exceptions."""
         sr = env.SensorReportAirGap(site_id=1, gap=10.0, draft=5.0)
 
         with pytest.raises(env.AisUnpackingException, match="bit length"):
@@ -1510,6 +1600,7 @@ class TestEnvironment:
             sr.get_bits()
 
     def test_air_gap_unicode(self):
+        """Test SensorReportAirGap string representation."""
         sr = env.SensorReportAirGap(
             site_id=1,
             draft=10.0,
@@ -1528,6 +1619,7 @@ class TestEnvironment:
     def test_environment_init_nmea_strings_and_verbose_unicode_and_eq_diff_reports_and_html(
         self, monkeypatch
     ):
+        """Test Environment initialization, unicode formatting, and comparison with different report types."""
         monkeypatch.setattr(env.Environment, "decode_nmea", lambda self, strings: None)
         e = env.Environment(
             nmea_strings=["!AIVDM,1,1,0,A,85M:Ih1KmPAU6jAs85`03cJm;1NHQhPFP000,0*19"]
@@ -1545,6 +1637,7 @@ class TestEnvironment:
             e2.html()
 
     def test_current_horz_coverage(self, monkeypatch):
+        """Test SensorReportCurrentHorz exception handling and unicode formatting."""
         sr = env.SensorReportCurrentHorz(site_id=1)
 
         with pytest.raises(env.AisUnpackingException, match="bit length"):
@@ -1569,6 +1662,7 @@ class TestEnvironment:
         assert "SensorReport CurrentHorz: site_id=1" in u
 
     def test_sea_state_coverage(self, monkeypatch):
+        """Test SensorReportSeaState exception handling and unicode formatting."""
         sr = env.SensorReportSeaState(site_id=1)
 
         with pytest.raises(env.AisUnpackingException, match="bit length"):
@@ -1593,6 +1687,7 @@ class TestEnvironment:
         assert "SensorReport SeaState: site_id=1" in u
 
     def test_salinity_coverage(self, monkeypatch):
+        """Test SensorReportSalinity exception handling and unicode formatting."""
         sr = env.SensorReportSalinity(site_id=1)
 
         with pytest.raises(env.AisUnpackingException, match="bit length"):
@@ -1617,6 +1712,7 @@ class TestEnvironment:
         assert "SensorReport Salinity: site_id=1" in u
 
     def test_weather_coverage(self, monkeypatch):
+        """Test SensorReportWeather exception handling and unicode formatting."""
         sr = env.SensorReportWeather(site_id=1)
 
         with pytest.raises(env.AisUnpackingException, match="bit length"):
@@ -1641,6 +1737,7 @@ class TestEnvironment:
         assert "SensorReport Wx: site_id=1" in u
 
     def test_wind_coverage(self, monkeypatch):
+        """Test SensorReportWind exception handling and unicode formatting."""
         sr = env.SensorReportWind(
             site_id=1,
             speed=10,
@@ -1674,6 +1771,7 @@ class TestEnvironment:
         assert "forecast: speed=12" in u
 
     def test_water_level_coverage(self, monkeypatch):
+        """Test SensorReportWaterLevel exception handling and unicode formatting."""
         sr = env.SensorReportWaterLevel(site_id=1, wl=1.5, forecast_wl=2.0)
 
         with pytest.raises(env.AisUnpackingException, match="bit length"):
@@ -1700,6 +1798,7 @@ class TestEnvironment:
         assert "forecast: wl=2.0" in u
 
     def test_current_2d_coverage(self, monkeypatch):
+        """Test SensorReportCurrent2d exception handling and unicode formatting."""
         sr = env.SensorReportCurrent2d(site_id=1, speed_1=5.0)
 
         with pytest.raises(env.AisUnpackingException, match="bit length"):
@@ -1725,6 +1824,7 @@ class TestEnvironment:
         assert "speed=5.0" in u
 
     def test_current_3d_coverage(self, monkeypatch):
+        """Test SensorReportCurrent3d exception handling and unicode formatting."""
         sr = env.SensorReportCurrent3d(site_id=1, n_1=5.0, level_1=10)
 
         with pytest.raises(env.AisUnpackingException, match="bit length"):
@@ -1750,6 +1850,7 @@ class TestEnvironment:
         assert "n=5.0" in u
 
     def test_sensor_report_base_and_location_and_id_coverage(self, monkeypatch):
+        """Test base SensorReport, Location, and Id coverage edge cases."""
         sr1 = env.SensorReportLocation(site_id=1, lon=10.0, lat=20.0, alt=30.0)
         sr2 = env.SensorReportLocation(site_id=1, lon=15.0, lat=20.0, alt=30.0)
         assert sr1 != sr2

--- a/tests/imo_001_31_met_hydro_test.py
+++ b/tests/imo_001_31_met_hydro_test.py
@@ -160,7 +160,7 @@ def test_unicode_and_str():
     assert mh.__unicode__() == "MetHydro31: "
     assert "MetHydro31: " in mh.__unicode__(verbose=True)
     assert str(mh) == "MetHydro31: "
-    assert "MetHydro31: " in mh.__str__(verbose=True)
+    assert "MetHydro31: " in mh.__unicode__(verbose=True)
 
 
 def test_eq_branches():

--- a/tests/imo_001_31_met_hydro_test.py
+++ b/tests/imo_001_31_met_hydro_test.py
@@ -18,6 +18,11 @@ FUZZ_COUNT = 30
 
 
 def random_msg():
+    """Generate a random MetHydro31 message for testing.
+
+    Returns:
+        A randomized MetHydro31 instance.
+    """
     date = random_date()
     sys.stderr.write(f"date: {date}\n")
     return met_hydro.MetHydro31(
@@ -63,6 +68,7 @@ def random_msg():
 
 
 def test_empty():
+    """Test default MetHydro31 message serialization and deserialization."""
     mh = met_hydro.MetHydro31(source_mmsi=123456789)
     assert mh == mh  # pylint: disable=comparison-with-itself
     mh_b = met_hydro.MetHydro31(bits=mh.get_bits())
@@ -79,6 +85,7 @@ def test_random():
 
 
 def test_ne_and_html_and_geo_interface():
+    """Test inequality operator and unimplemented html / geo interface properties."""
     mh1 = met_hydro.MetHydro31(source_mmsi=123456789)
     mh2 = met_hydro.MetHydro31(source_mmsi=987654321)
     assert mh1 != mh2
@@ -89,6 +96,7 @@ def test_ne_and_html_and_geo_interface():
 
 
 def test_get_bits_wrong_size_error(monkeypatch):
+    """Test get_bits raises exception when message size is invalid."""
     mh = met_hydro.MetHydro31(source_mmsi=123456789)
 
     monkeypatch.setattr(met_hydro.binary, "joinBV", lambda bv_list: BitVector(size=100))
@@ -97,6 +105,7 @@ def test_get_bits_wrong_size_error(monkeypatch):
 
 
 def test_decode_nmea_errors():
+    """Test NMEA sentence decoding error handling."""
     mh = met_hydro.MetHydro31(source_mmsi=123456789)
     with pytest.raises(met_hydro.AisUnpackingException, match="Checksum failed"):
         mh.decode_nmea(["!AIVDM,1,1,0,A,85M:Ih1KmPAU6jAs85`03cJm;1NHQhPFP000,0*99"])
@@ -109,16 +118,20 @@ def test_decode_nmea_errors():
 
 
 def test_decode_nmea_none_in_msgs(monkeypatch):
+    """Test NMEA decoding with fake regex matches."""
+
     class FakeMatch1:
         """Fake NMEA regex match with checksum."""
 
         def groupdict(self):
+            """Return groupdict with valid checksum."""
             return {"checksum": "19"}
 
     class FakeMatch2:
         """Fake NMEA regex match with no groupdict."""
 
         def groupdict(self):
+            """Return None for groupdict."""
             return None
 
     class FakeRegex:
@@ -128,6 +141,7 @@ def test_decode_nmea_none_in_msgs(monkeypatch):
             self.calls = 0
 
         def search(self, text):
+            """Simulate regex search calls returning fake matches."""
             self.calls += 1
             if self.calls == 1:
                 return FakeMatch1()
@@ -141,6 +155,7 @@ def test_decode_nmea_none_in_msgs(monkeypatch):
 
 
 def test_unicode_and_str():
+    """Test string representation of MetHydro31 objects."""
     mh = met_hydro.MetHydro31(source_mmsi=123456789)
     assert mh.__unicode__() == "MetHydro31: "
     assert "MetHydro31: " in mh.__unicode__(verbose=True)
@@ -149,6 +164,7 @@ def test_unicode_and_str():
 
 
 def test_eq_branches():
+    """Test branch paths in equality comparison operator."""
     mh1 = met_hydro.MetHydro31(source_mmsi=123456789)
     mh2 = met_hydro.MetHydro31(source_mmsi=123456789)
 
@@ -176,6 +192,7 @@ def test_eq_branches():
 
 
 def test_get_bits_no_mmsi_error():
+    """Test get_bits raises exception when MMSI is missing."""
     mh = met_hydro.MetHydro31(source_mmsi=123456789)
     mh.source_mmsi = None
     with pytest.raises(met_hydro.AisPackingException, match="No mmsi specified"):
@@ -183,6 +200,7 @@ def test_get_bits_no_mmsi_error():
 
 
 def test_init_nmea_strings():
+    """Test initializing MetHydro31 with NMEA strings."""
     with pytest.raises(NotImplementedError):
         met_hydro.MetHydro31(
             nmea_strings=["!AIVDM,1,1,0,A,85M:Ih1KmPAU6jAs85`03cJm;1NHQhPFP000,0*19"]
@@ -190,6 +208,7 @@ def test_init_nmea_strings():
 
 
 def test_init_nmea_strings_return(monkeypatch):
+    """Test initializing MetHydro31 with NMEA strings early return."""
     monkeypatch.setattr(met_hydro.MetHydro31, "decode_nmea", lambda self, strings: None)
     mh = met_hydro.MetHydro31(
         nmea_strings=["!AIVDM,1,1,0,A,85M:Ih1KmPAU6jAs85`03cJm;1NHQhPFP000,0*19"]
@@ -198,6 +217,7 @@ def test_init_nmea_strings_return(monkeypatch):
 
 
 def test_init_none_day_hour_minute():
+    """Test initializing MetHydro31 with None timestamp defaults to current time."""
     mh = met_hydro.MetHydro31(source_mmsi=123456789, day=None, hour=None, minute=None)
     assert mh.day is not None
     assert mh.hour is not None

--- a/tests/imo_001_31_met_hydro_test.py
+++ b/tests/imo_001_31_met_hydro_test.py
@@ -140,7 +140,7 @@ def test_decode_nmea_none_in_msgs(monkeypatch):
         def __init__(self):
             self.calls = 0
 
-        def search(self, text):
+        def search(self, _text):
             """Simulate regex search calls returning fake matches."""
             self.calls += 1
             if self.calls == 1:

--- a/tests/m366_22_test.py
+++ b/tests/m366_22_test.py
@@ -10,11 +10,13 @@ from ais_area_notice import m366_22
 
 
 def test_empty_init():
+    """Test initializing AreaNotice without arguments raises Error."""
     with pytest.raises(m366_22.Error):
         m366_22.AreaNotice()
 
 
 def test_init_with_area_type():
+    """Test initializing AreaNotice with area_type and timestamp."""
     area_type = 1
     now = datetime.datetime.utcnow()
     an = m366_22.AreaNotice(area_type=area_type, when=now)
@@ -32,6 +34,7 @@ def test_init_with_area_type():
 
 
 def test_circle():
+    """Test decoding AreaNotice with a single circle subarea from NMEA sentences."""
     aivdm = "!AIVDM,1,1,0,A,85M:Ih1KUQU6jAs85`0MK4lh<7=B42l0000,2*7F"
     an = m366_22.AreaNotice(nmea_strings=[aivdm])
     assert len(an.areas) == 1
@@ -41,6 +44,7 @@ def test_circle():
 
 
 def test_area_notice_circle_init_and_get_bits():
+    """Test AreaNoticeCircle initialization, bit packing, and decoding."""
     c1 = m366_22.AreaNoticeCircle(
         lon=-71.935, lat=41.236666667, radius=1800, precision=4, scale_factor=10
     )
@@ -59,6 +63,7 @@ def test_area_notice_circle_init_and_get_bits():
 
 
 def test_add_subarea_no_areas_attr_and_max_areas_exceeded():
+    """Test adding subareas handles missing areas attribute and enforces maximum limit."""
     when = datetime.datetime(2026, 9, 4, 15, 25)
     an = m366_22.AreaNotice(area_type=1, when=when)
     del an.areas
@@ -75,6 +80,7 @@ def test_add_subarea_no_areas_attr_and_max_areas_exceeded():
 
 
 def test_decode_nmea_errors_and_none_in_msgs(monkeypatch):
+    """Test NMEA decoding error handling and invalid regex matches."""
     with pytest.raises(m366_22.AisUnpackingException, match="Checksum failed"):
         m366_22.AreaNotice(
             nmea_strings=["!AIVDM,1,1,0,A,85M:Ih1KUQU6jAs85`0MK4lh<7=B42l0000,2*00"]
@@ -87,12 +93,14 @@ def test_decode_nmea_errors_and_none_in_msgs(monkeypatch):
         """Fake NMEA regex match with checksum."""
 
         def groupdict(self):
+            """Return groupdict with valid checksum."""
             return {"checksum": "7F"}
 
     class FakeMatch2:
         """Fake NMEA regex match with no groupdict."""
 
         def groupdict(self):
+            """Return None for groupdict."""
             return None
 
     class FakeRegex:
@@ -102,6 +110,7 @@ def test_decode_nmea_errors_and_none_in_msgs(monkeypatch):
             self.calls = 0
 
         def search(self, text):
+            """Simulate regex search calls returning fake matches."""
             self.calls += 1
             if self.calls == 1:
                 return FakeMatch1()
@@ -115,6 +124,7 @@ def test_decode_nmea_errors_and_none_in_msgs(monkeypatch):
 
 
 def test_subarea_factory_overflow_and_unsupported_shape():
+    """Test subarea count overflow and unsupported shape error handling."""
     aivdm = "!AIVDM,1,1,0,A,85M:Ih1KUQU6jAs85`0MK4lh<7=B42l0000,2*7F"
     an = m366_22.AreaNotice(nmea_strings=[aivdm])
 
@@ -138,6 +148,7 @@ def test_subarea_factory_overflow_and_unsupported_shape():
 
 
 def test_scale_factors_and_del_scale_factor():
+    """Test scale factor computation and lazy evaluation in get_bits."""
     subarea = m366_22.AreaNoticeSubArea()
     assert subarea.getScaleFactor(500000) == 1000
     assert subarea.getScaleFactor(50000) == 100
@@ -150,6 +161,7 @@ def test_scale_factors_and_del_scale_factor():
 
 
 def test_subarea_factory_shapes_1_2_3_4_5(monkeypatch):
+    """Test subarea factory routing and error handling for all shape types."""
     aivdm = "!AIVDM,1,1,0,A,85M:Ih1KUQU6jAs85`0MK4lh<7=B42l0000,2*7F"
     an = m366_22.AreaNotice(nmea_strings=[aivdm])
 

--- a/tests/m366_22_test.py
+++ b/tests/m366_22_test.py
@@ -109,7 +109,7 @@ def test_decode_nmea_errors_and_none_in_msgs(monkeypatch):
         def __init__(self):
             self.calls = 0
 
-        def search(self, text):
+        def search(self, _text):
             """Simulate regex search calls returning fake matches."""
             self.calls += 1
             if self.calls == 1:

--- a/tests/m367_22_test.py
+++ b/tests/m367_22_test.py
@@ -39,6 +39,11 @@ class DiffAreaNotice:
             self.CheckField(field)
 
     def CheckField(self, field):
+        """Compare a specific attribute field between two AreaNotice instances.
+
+        Args:
+            field: Name of the attribute field to compare.
+        """
         val1 = self.an1.__dict__[field]
         val2 = self.an2.__dict__[field]
         if val1 != val2:
@@ -49,12 +54,23 @@ class TestAreaNotice:
     """Tests for AreaNotice (8:367:22) encoding, decoding, and subareas."""
 
     def checkHeader(self, area_notice, mmsi=366123456):
+        """Verify common AIS message header fields.
+
+        Args:
+            area_notice: AreaNotice instance to verify.
+            mmsi: Expected MMSI identifier.
+        """
         assert area_notice.message_id == 8
         assert area_notice.repeat_indicator == 0
         assert area_notice.mmsi == mmsi
         assert area_notice.spare == 0
 
     def checkDacFi(self, area_notice):
+        """Verify DAC and FI fields in AreaNotice.
+
+        Args:
+            area_notice: AreaNotice instance to verify.
+        """
         assert area_notice.dac == 367  # One of thr USA DACs.
         assert area_notice.fi == 22  # Area notice.
 
@@ -74,6 +90,16 @@ class TestAreaNotice:
             assert area_notice.spare2 == 0
 
     def checkCircle(self, subarea, scale_factor, lon, lat, precision, radius):
+        """Verify AreaNoticeCircle subarea fields.
+
+        Args:
+            subarea: Subarea instance to verify.
+            scale_factor: Expected scale factor multiplier.
+            lon: Expected longitude.
+            lat: Expected latitude.
+            precision: Expected position precision bits.
+            radius: Expected radius in meters.
+        """
         assert subarea.area_shape == SHAPES["CIRCLE"]
         assert subarea.scale_factor == scale_factor
         assert subarea.lon == pytest.approx(lon)
@@ -96,6 +122,18 @@ class TestAreaNotice:
         n_dim,
         orientation_deg,
     ):
+        """Verify AreaNoticeRectangle subarea fields.
+
+        Args:
+            subarea: Subarea instance to verify.
+            scale_factor: Expected scale factor multiplier.
+            lon: Expected longitude.
+            lat: Expected latitude.
+            precision: Expected position precision bits.
+            e_dim: Expected east dimension width in meters.
+            n_dim: Expected north dimension height in meters.
+            orientation_deg: Expected orientation in degrees.
+        """
         assert subarea.area_shape == SHAPES["RECTANGLE"]
         assert subarea.scale_factor == scale_factor
         assert subarea.lon == pytest.approx(lon)
@@ -121,6 +159,18 @@ class TestAreaNotice:
         left_bound_deg,
         right_bound_deg,
     ):
+        """Verify AreaNoticeSector subarea fields.
+
+        Args:
+            subarea: Subarea instance to verify.
+            scale_factor: Expected scale factor multiplier.
+            lon: Expected longitude.
+            lat: Expected latitude.
+            precision: Expected position precision bits.
+            radius: Expected radius in meters.
+            left_bound_deg: Expected left boundary angle in degrees.
+            right_bound_deg: Expected right boundary angle in degrees.
+        """
         assert subarea.area_shape == SHAPES["SECTOR"]
         assert subarea.scale_factor == scale_factor
         assert subarea.lon == pytest.approx(lon)
@@ -135,6 +185,16 @@ class TestAreaNotice:
             assert subarea.spare == 0
 
     def checkPoly(self, sub_area, area_shape, scale_factor, lon, lat, points):
+        """Verify AreaNoticePoly subarea fields.
+
+        Args:
+            sub_area: Subarea instance to verify.
+            area_shape: Expected shape type ID (3 for polyline, 4 for polygon).
+            scale_factor: Expected scale factor multiplier.
+            lon: Expected longitude or None.
+            lat: Expected latitude or None.
+            points: Expected list of (angle, distance) tuples.
+        """
         assert area_shape in (3, 4)
         assert sub_area.area_shape == area_shape
         assert sub_area.scale_factor == scale_factor
@@ -148,6 +208,12 @@ class TestAreaNotice:
         assert sub_area.spare == 0
 
     def checkText(self, sub_area, expected_text):
+        """Verify AreaNoticeText subarea fields.
+
+        Args:
+            sub_area: Subarea instance to verify.
+            expected_text: Expected string content.
+        """
         if "area_shape" in sub_area.__dict__:
             assert sub_area.area_shape == SHAPES["TEXT"]
         assert sub_area.text == expected_text
@@ -155,6 +221,7 @@ class TestAreaNotice:
             assert sub_area.spare == 0
 
     def testCircle(self):
+        """Test decoding circle area notice NMEA sample."""
         msg = "!AIVDM,1,1,0,A,85M:Ih1KmPAU6jAs85`03cJm;1NHQhPFP000,0*19"
         area_notice = AreaNotice(nmea_strings=[msg])
         self.checkHeader(area_notice)
@@ -179,6 +246,7 @@ class TestAreaNotice:
         )
 
     def testOnlyCircleEncode(self):
+        """Test AreaNoticeCircle standalone encoding and decoding."""
         lon = 1.0
         lat = -2.0
         radius = 4
@@ -211,6 +279,7 @@ class TestAreaNotice:
         self.checkCircle(c3, 10, lon, lat, precision, radius)
 
     def testCircleEncode(self):
+        """Test AreaNotice with circle subarea encoding and NMEA generation."""
         # Test against 'Sample AN Data RTCMv1.xlsx' circle
         year = datetime.datetime.utcnow().year
         when = datetime.datetime(year, 9, 4, 15, 25)
@@ -241,6 +310,7 @@ class TestAreaNotice:
         assert lines[0] == expected_msg
 
     def testRectangle(self):
+        """Test decoding rectangle area notice NMEA sample."""
         msg = "!AIVDM,1,1,0,A,85M:Ih1KmPAVhjAs80e0;cKBN1N:W8Q@:2`0,0*0C"
         area_notice = AreaNotice(nmea_strings=[msg])
         self.checkHeader(area_notice)
@@ -276,6 +346,7 @@ class TestAreaNotice:
         )
 
     def testEncodeRectMatchingUSCG(self):
+        """Test encoding AreaNoticeRectangle matching USCG test vector."""
         msg = "!AIVDM,1,1,0,A,85M:Ih1KmPAVhjAs80e0;cKBN1N:W8Q@:2`0,0*0C"
         sub_area_msg = msg.split(",")[5][-16:]
         sa1_bits = binary.ais6tobitvec(sub_area_msg)
@@ -306,6 +377,7 @@ class TestAreaNotice:
         assert sa1_bits == sa2_bits
 
     def testRectangleEncode(self):
+        """Test AreaNotice with rectangle subarea encoding and NMEA generation."""
         year = datetime.datetime.utcnow().year
         when = datetime.datetime(year, 9, 4, 15, 25)
 
@@ -342,6 +414,7 @@ class TestAreaNotice:
         assert lines[0] == expected_msg
 
     def testSector(self):
+        """Test decoding sector area notice NMEA sample."""
         msg = "!AIVDM,1,1,0,A,85M:Ih1KmPAW5BAs80e0EcN<11N6th@6BgL8,0*13"
         area_notice = AreaNotice(nmea_strings=[msg])
         self.checkHeader(area_notice)
@@ -368,6 +441,7 @@ class TestAreaNotice:
         )
 
     def testEncodeSectorMatchingUSCG(self):
+        """Test encoding AreaNoticeSector matching USCG test vector."""
         msg = "!AIVDM,1,1,0,A,85M:Ih1KmPAW5BAs80e0EcN<11N6th@6BgL8,0*13"
         sub_area_msg = msg.split(",")[5][-16:]
         sa1_bits = binary.ais6tobitvec(sub_area_msg)
@@ -390,6 +464,7 @@ class TestAreaNotice:
         assert sa1_bits == sa2_bits
 
     def testPolylineAndText(self):
+        """Test decoding multi-sentence AreaNotice with polyline and text subareas."""
         msg = [
             (
                 "!AIVDM,2,1,0,A,85M:Ih1KmPA`tBAs85`01cON31N;U`P00000H;Gl1gfp52tjFq20H3r9P000,0*64"
@@ -427,6 +502,7 @@ class TestAreaNotice:
         self.checkText(text_block, "TEST LINE 1")
 
     def testPolylineOnly(self):
+        """Test AreaNoticePoly standalone encoding and decoding."""
         msg = [
             (
                 "!AIVDM,2,1,0,A,85M:Ih1KmPA`tBAs85`01cON31N;U`P00000H;Gl1gfp52tjFq20H3r9P000,0*64"
@@ -452,6 +528,7 @@ class TestAreaNotice:
         assert sa1_bits == sa2_bits
 
     def testPolygon(self):
+        """Test decoding polygon area notice NMEA sample."""
         msg = "!AIVDM,1,1,0,A,85M:Ih1KmPAa8jAs85`01cN:41NI@`P00000P7Td4dUP00000000,0*71"
         area_notice = AreaNotice(nmea_strings=[msg])
         self.checkHeader(area_notice)
@@ -471,6 +548,7 @@ class TestAreaNotice:
         self.checkPoly(area_notice.areas[0], 4, 1, lon, lat, points)
 
     def testTextOnly(self):
+        """Test AreaNoticeText standalone encoding and decoding."""
         msg = [
             (
                 "!AIVDM,2,1,0,A,85M:Ih1KmPA`tBAs85`01cON31N;U`P00000H;Gl1gfp52tjFq20H3r9P000,0*64"
@@ -488,11 +566,13 @@ class TestAreaNotice:
         assert sa1_bits == sa2_bits
 
     def test_poly_empty_points_padding(self):
+        """Test polyline encoding with empty point padding."""
         poly = AreaNoticePoly(SHAPES["POLYLINE"], [(10.0, 100)], scale_factor=1)
         bits = poly.get_bits()
         assert len(bits) == 96
 
     def test_add_subarea_no_areas_attr_and_max_areas_exceeded(self):
+        """Test subarea addition limits and attribute handling."""
         when = datetime.datetime(2026, 9, 4, 15, 25)
         an = AreaNotice(
             area_type=13, when=when, duration_min=60, link_id=1, mmsi=366123456
@@ -511,6 +591,7 @@ class TestAreaNotice:
             an.add_subarea(circle)
 
     def test_get_bits_include_bin_hdr_and_too_large_error(self):
+        """Test binary header inclusion and message size overflow check."""
         when = datetime.datetime(2026, 9, 4, 15, 25)
         an = AreaNotice(
             area_type=13, when=when, duration_min=60, link_id=1, mmsi=366123456
@@ -528,6 +609,7 @@ class TestAreaNotice:
             an.get_bits()
 
     def test_decode_nmea_errors_and_fill_bits(self):
+        """Test NMEA error handling and fill bits processing."""
         with pytest.raises(AisUnpackingException, match="Checksum failed"):
             AreaNotice(
                 nmea_strings=[
@@ -546,6 +628,7 @@ class TestAreaNotice:
         assert len(an_fill.areas) == 1
 
     def test_subarea_factory_invalid_preceding_shape(self):
+        """Test subarea factory throws error for invalid shape sequence."""
         when = datetime.datetime(2026, 9, 4, 15, 25)
         an = AreaNotice(
             area_type=13, when=when, duration_min=60, link_id=1, mmsi=366123456
@@ -567,11 +650,13 @@ class TestAreaNotice:
             AreaNotice(nmea_strings=None).decode_bits(invalid_bits)
 
     def test_decode_bits_verify_log(self):
+        """Test DecodeBits verification failure logging."""
         db = DecodeBits(BitVector.from_bitstring("0000"))
         with pytest.raises(AssertionError):
             db.Verify(10)
 
     def test_scale_factors_and_defaults(self):
+        """Test scale factor auto-computation and default property evaluation."""
         subarea = AreaNoticeCircle(lon=1.0, lat=2.0, radius=500000, scale_factor=None)
         assert subarea.getScaleFactor(500000) == 1000
         assert subarea.getScaleFactor(50000) == 100
@@ -606,16 +691,20 @@ class TestAreaNotice:
         assert len(poly.get_bits()) == 96
 
     def test_decode_nmea_none_in_msgs(self, monkeypatch):
+        """Test NMEA decoding with fake regex matches."""
+
         class FakeMatch1:
             """Fake NMEA regex match with checksum."""
 
             def groupdict(self):
+                """Return groupdict with valid checksum."""
                 return {"checksum": "06"}
 
         class FakeMatch2:
             """Fake NMEA regex match with no groupdict."""
 
             def groupdict(self):
+                """Return None for groupdict."""
                 return None
 
         class FakeRegex:
@@ -625,6 +714,7 @@ class TestAreaNotice:
                 self.calls = 0
 
             def search(self, text):
+                """Simulate regex search calls returning fake matches."""
                 self.calls += 1
                 if self.calls == 1:
                     return FakeMatch1()

--- a/tests/m367_22_test.py
+++ b/tests/m367_22_test.py
@@ -713,7 +713,7 @@ class TestAreaNotice:
             def __init__(self):
                 self.calls = 0
 
-            def search(self, text):
+            def search(self, _text):
                 """Simulate regex search calls returning fake matches."""
                 self.calls += 1
                 if self.calls == 1:


### PR DESCRIPTION
  ### Resolved Pylint Warning Messages

   Pylint Symbol             | Code                 | Category            | Resolved Count      | Description
  ---------------------------|----------------------|---------------------|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------
   unnecessary-comprehension | R1721                | refactor            | 10                  | Replaced list comprehensions of generator expressions (e.g. [x for x in msg.get_aivdm()]) with list(msg.get_aivdm()) in tests/imo_001_22_area_notice_test.py.
   unnecessary-dunder-call   | C0280                | convention          | 3                   | Replaced explicit self.__str__() with str(self) in imo_001_22_area_notice.py and e.__str__(verbose=True) with e.__unicode__(verbose=True).
   unspecified-encoding      | W1514                | warning             | 1                   | Re-enabled unspecified-encoding check in .pylintrc.
   redefined-builtin         | W0622                | warning             | 1                   | Inlined # pylint: disable=redefined-builtin for parameter dir=360 in SensorReportWind.__init__.
   unused-argument           | W0613                | warning             | 12                  | Renamed unused parameters (kwargs, name, year, lon, lat, text, bv_list) to _-prefixed identifiers across package and tests.
   chained-comparison        | R1716                | refactor            | 63                  | Simplified multi-operand comparison expressions into pythonic chained range assertions (min <= x <= max) across package modules.
   deprecated-module         | W0402                | warning             | 1                   | Re-enabled deprecated-module check in .pylintrc.
