### PR TITLE
refactor(lint): convert names to snake_case to fix pylint invalid-name warnings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -11,7 +11,6 @@ disable =
     fixme,
     global-statement,
     inconsistent-return-statements,
-    invalid-name,
     invalid-unary-operand-type,
     line-too-long,
     no-member,

--- a/ais_area_notice/__init__.py
+++ b/ais_area_notice/__init__.py
@@ -1,3 +1,4 @@
 """AIS Area Notice package."""
 
-version: str = "0.5"
+__version__: str = "0.5"
+VERSION: str = __version__

--- a/ais_area_notice/ais_string.py
+++ b/ais_area_notice/ais_string.py
@@ -154,7 +154,7 @@ character_bits: dict[str, BitVector] = {
 }
 
 
-def Decode(bits: BitVector, drop_after_first_at: bool = False) -> str:
+def decode(bits: BitVector, drop_after_first_at: bool = False) -> str:
     """Decode bits as a string.
 
     Does not remove the end space or @@@@.  Must be an multiple of 6 bits.
@@ -180,7 +180,11 @@ def Decode(bits: BitVector, drop_after_first_at: bool = False) -> str:
     return "".join(s)
 
 
-def Encode(string: str, bit_size: int | None = None) -> BitVector:
+# Backward compatibility alias
+Decode = decode  # pylint: disable=invalid-name
+
+
+def encode(string: str, bit_size: int | None = None) -> BitVector:
     """Convert a string to a BitVector.
 
     TODO(schwehr): Pad with "@" to reach requested bitSize.
@@ -209,7 +213,11 @@ def Encode(string: str, bit_size: int | None = None) -> BitVector:
     return bv
 
 
-def Strip(string: str, remove_blanks: bool = True) -> str:
+# Backward compatibility alias
+Encode = encode  # pylint: disable=invalid-name
+
+
+def strip(string: str, remove_blanks: bool = True) -> str:
     """Remove AIS string padding @ characters and spaces on the right.
 
     Args:
@@ -225,7 +233,11 @@ def Strip(string: str, remove_blanks: bool = True) -> str:
     return string
 
 
-def Pad(string: str, length: int) -> str:
+# Backward compatibility alias
+Strip = strip  # pylint: disable=invalid-name
+
+
+def pad(string: str, length: int) -> str:
     """Pad string to length with @ characters.
 
     Args:
@@ -235,7 +247,11 @@ def Pad(string: str, length: int) -> str:
     Returns:
         str of the require length that is right padded.
     """
-    pad = length - len(string)
-    if pad > 0:
-        string += "@" * pad
+    pad_len = length - len(string)
+    if pad_len > 0:
+        string += "@" * pad_len
     return string
+
+
+# Backward compatibility alias
+Pad = pad  # pylint: disable=invalid-name

--- a/ais_area_notice/an_util.py
+++ b/ais_area_notice/an_util.py
@@ -20,8 +20,8 @@ class DecodeBits:
         self.bits = bits
         self.pos = 0
 
-    # TODO(schwehr): This method name should be GetUInt.
-    def GetInt(self, length: int) -> int:
+    # TODO(schwehr): This method name should be get_uint.
+    def get_int(self, length: int) -> int:
         """Read an unsigned integer of specified bit length from the bitstream.
 
         Args:
@@ -35,8 +35,10 @@ class DecodeBits:
         self.pos += length
         return value
 
-    # TODO(schwehr): This method name should be GetInt.
-    def GetSignedInt(self, length: int) -> int:
+    GetInt = get_int
+
+    # TODO(schwehr): This method name should be get_int.
+    def get_signed_int(self, length: int) -> int:
         """Read a signed integer of specified bit length from the bitstream.
 
         Args:
@@ -46,11 +48,13 @@ class DecodeBits:
             The signed integer value decoded from the bit slice.
         """
         end = self.pos + length
-        value = binary.signedIntFromBV(self.bits[self.pos : end])
+        value = binary.signed_int_from_bv(self.bits[self.pos : end])
         self.pos += length
         return value
 
-    def GetText(self, length: int, strip: bool = True) -> str:
+    GetSignedInt = get_signed_int
+
+    def get_text(self, length: int, strip: bool = True) -> str:
         """Read 6-bit AIS character text of specified bit length from the bitstream.
 
         Args:
@@ -66,14 +70,16 @@ class DecodeBits:
         if length % 6 != 0:
             raise Error("Bits for text must be six bit aligned.")
         end = self.pos + length
-        text = ais_string.Decode(self.bits[self.pos : end])
+        text = ais_string.decode(self.bits[self.pos : end])
         at = text.find("@")
         if strip and at != -1:
             text = text[:at]
         self.pos += length
         return text
 
-    def Verify(self, offset: int) -> None:
+    GetText = get_text
+
+    def verify(self, offset: int) -> None:
         """Verify that current bit read position matches the expected offset.
 
         Args:
@@ -84,6 +90,8 @@ class DecodeBits:
         """
         if self.pos != offset:
             raise Error(f"Decode verify failed.  {self.pos} != {offset}")
+
+    Verify = verify
 
 
 class BuildBits:
@@ -96,21 +104,25 @@ class BuildBits:
         self.bv_list = []
         self.bits_expected = 0
 
-    def AddUInt(self, val: int, num_bits: int) -> None:
+    def add_uint(self, val: int, num_bits: int) -> None:
         """Add an unsigned integer."""
-        bits = binary.setBitVectorSize(BitVector.from_int(val), num_bits)
+        bits = binary.set_bit_vector_size(BitVector.from_int(val), num_bits)
         assert num_bits == len(bits)
         self.bits_expected += num_bits
         self.bv_list.append(bits)
 
-    def AddInt(self, val: int, num_bits: int) -> None:
+    AddUInt = add_uint
+
+    def add_int(self, val: int, num_bits: int) -> None:
         """Add a signed integer."""
-        bits = binary.bvFromSignedInt(int(val), num_bits)
+        bits = binary.bv_from_signed_int(int(val), num_bits)
         assert num_bits == len(bits)
         self.bits_expected += num_bits
         self.bv_list.append(bits)
 
-    def AddText(self, val: str, num_bits: int) -> None:
+    AddInt = add_int
+
+    def add_text(self, val: str, num_bits: int) -> None:
         """Add 6-bit AIS encoded text of specified bit length to the bitstream.
 
         Args:
@@ -120,11 +132,13 @@ class BuildBits:
         num_char = num_bits // 6
         assert num_bits % 6 == 0
         text = val.ljust(num_char, "@")
-        bits = ais_string.Encode(text)
+        bits = ais_string.encode(text)
         self.bits_expected += num_bits
         self.bv_list.append(bits)
 
-    def Verify(self, num_bits: int) -> None:
+    AddText = add_text
+
+    def verify(self, num_bits: int) -> None:
         """Verify that total packed bits match expected bit count.
 
         Args:
@@ -136,7 +150,9 @@ class BuildBits:
         if self.bits_expected != num_bits:
             raise Error(f"BuildBits did not verify: {self.bits_expected} != {num_bits}")
 
-    def GetBits(self) -> BitVector:
+    Verify = verify
+
+    def get_bits(self) -> BitVector:
         """Concatenate all bit vectors in the list into a single BitVector.
 
         Returns:
@@ -145,7 +161,9 @@ class BuildBits:
         Raises:
             Error: If combined length does not match expected bit count.
         """
-        bits = binary.joinBV(self.bv_list)
+        bits = binary.join_bv(self.bv_list)
         if len(bits) != self.bits_expected:
             raise Error("BuildBits did not match expected bits.")
         return bits
+
+    GetBits = get_bits

--- a/ais_area_notice/binary.py
+++ b/ais_area_notice/binary.py
@@ -29,6 +29,7 @@ Attributes:
 """
 
 from collections.abc import Sequence
+from typing import Any
 
 from BitVector import BitVector
 
@@ -42,7 +43,7 @@ END_ASCII_BLOCK_2: int = 119  # 'w'
 GAP_SIZE: int = BGN_ASCII_BLOCK_2 - (END_ASCII_BLOCK_1 + 1)
 
 
-def setBitVectorSize(bv: BitVector, size: int = 8) -> BitVector:
+def set_bit_vector_size(bv: BitVector, size: int = 8) -> BitVector:
     """Pad a BitVector with 0's on the left until it is the specified size.
 
     Args:
@@ -58,7 +59,10 @@ def setBitVectorSize(bv: BitVector, size: int = 8) -> BitVector:
     return bv
 
 
-def _Ais6ToBitvecSlow(str6: str) -> BitVector:
+setBitVectorSize = set_bit_vector_size  # pylint: disable=invalid-name
+
+
+def _ais6_to_bitvec_slow(str6: str) -> BitVector:
     """Convert an ITU AIS VDM 6 bit string into a bit vector.
 
     Args:
@@ -77,23 +81,29 @@ def _Ais6ToBitvecSlow(str6: str) -> BitVector:
         if val == 0:
             bv = BitVector(size=BITS_PER_VDM_CHARACTER)
         else:
-            bv = setBitVectorSize(BitVector.from_int(val), BITS_PER_VDM_CHARACTER)
+            bv = set_bit_vector_size(BitVector.from_int(val), BITS_PER_VDM_CHARACTER)
 
         bvtotal += bv
     return bvtotal
 
 
-def _BuildLookupTable() -> dict[str, BitVector]:
+_Ais6ToBitvecSlow = _ais6_to_bitvec_slow  # pylint: disable=invalid-name
+
+
+def _build_lookup_table() -> dict[str, BitVector]:
     """Create a dict of character keys with the BitVector repr as the value."""
     key_nums = list(range(BGN_ASCII_BLOCK_1, END_ASCII_BLOCK_1 + 1)) + list(
         range(BGN_ASCII_BLOCK_2, END_ASCII_BLOCK_2 + 1)
     )
     assert len(key_nums) == 64
     key_chars = [chr(key) for key in key_nums]
-    return {key_char: _Ais6ToBitvecSlow(key_char) for key_char in key_chars}
+    return {key_char: _ais6_to_bitvec_slow(key_char) for key_char in key_chars}
 
 
-decode: dict[str, BitVector] = _BuildLookupTable()
+_BuildLookupTable = _build_lookup_table  # pylint: disable=invalid-name
+
+
+decode: dict[str, BitVector] = _build_lookup_table()
 
 # Lookup the character representation for an AIS AIVDM message from the 6-bit
 # integer value.
@@ -106,24 +116,27 @@ encode: list[str] = [
 ]
 
 
-def joinBV(bvSeq: Sequence[BitVector]) -> BitVector:
+def join_bv(bv_seq: Sequence[BitVector]) -> BitVector:
     """Combined a sequence of bit vectors into one large BitVector.
 
     TODO(schwehr): Check performance and see if this can be done faster.
 
     Args:
-        bvSeq: sequence of bitvectors.
+        bv_seq: sequence of bitvectors.
 
     Returns:
         An aggregated BitVector.
     """
     bv_total = BitVector(size=0)
-    for bv in bvSeq:
+    for bv in bv_seq:
         bv_total += bv
     return bv_total
 
 
-def AddOne(bv: BitVector) -> BitVector:
+joinBV = join_bv  # pylint: disable=invalid-name
+
+
+def add_one(bv: BitVector) -> BitVector:
     """Add one bit to a bit vector.
 
     Overflows are silently dropped.
@@ -145,7 +158,10 @@ def AddOne(bv: BitVector) -> BitVector:
     return new
 
 
-def SubOne(bv: BitVector) -> BitVector:
+AddOne = add_one  # pylint: disable=invalid-name
+
+
+def sub_one(bv: BitVector) -> BitVector:
     """Subtract one bit from a bit vector.
 
     Args:
@@ -165,7 +181,12 @@ def SubOne(bv: BitVector) -> BitVector:
     return new
 
 
-def bvFromSignedInt(intVal: int, bitSize: int | None = None) -> BitVector:
+SubOne = sub_one  # pylint: disable=invalid-name
+
+
+def bv_from_signed_int(
+    int_val: int, bit_size: int | None = None, **kwargs: Any
+) -> BitVector:
     """Create a two's complement BitVector from a signed integer.
 
     Note that 110 and 10 are both -2.  Positives must have a '0' in the
@@ -173,8 +194,8 @@ def bvFromSignedInt(intVal: int, bitSize: int | None = None) -> BitVector:
     position.
 
     Args:
-        intVal: integer value to turn into a bit vector.
-        bitSize: optional size to flush out the number of bits.
+        int_val: integer value to turn into a bit vector.
+        bit_size: optional size to flush out the number of bits.
 
     Returns:
         A BitVector flushed out to the correct size.
@@ -182,27 +203,31 @@ def bvFromSignedInt(intVal: int, bitSize: int | None = None) -> BitVector:
     Raises:
         ValueError: If the bit size does not make sense.
     """
+    bit_size = kwargs.get("bitSize", bit_size)
     bv = None
-    if not bitSize:
-        bv = BitVector.from_int(abs(intVal))
+    if not bit_size:
+        bv = BitVector.from_int(abs(int_val))
     else:
-        bv = setBitVectorSize(BitVector.from_int(abs(intVal)), bitSize - 1)
-        if bitSize - 1 != len(bv) and not (
-            len(bv) == bitSize and bv[0] == 1 and bv[-1] == 0
+        bv = set_bit_vector_size(BitVector.from_int(abs(int_val)), bit_size - 1)
+        if bit_size - 1 != len(bv) and not (
+            len(bv) == bit_size and bv[0] == 1 and bv[-1] == 0
         ):
             raise ValueError("incorrect bit size")
-        if len(bv) == bitSize and bv[0] == 1:
+        if len(bv) == bit_size and bv[0] == 1:
             return bv
-    if intVal >= 0:
+    if int_val >= 0:
         bv = BitVector.from_int(0, size=1) + bv
     else:
-        bv = SubOne(bv)
+        bv = sub_one(bv)
         bv = ~bv
         bv = BitVector.from_int(1, size=1) + bv
     return bv
 
 
-def signedIntFromBV(bv: BitVector) -> int:
+bvFromSignedInt = bv_from_signed_int  # pylint: disable=invalid-name
+
+
+def signed_int_from_bv(bv: BitVector) -> int:
     """Interpret a bit vector as an signed integer.
 
     int(BitVector) defaults to treating the bits as an unsigned int.
@@ -218,10 +243,13 @@ def signedIntFromBV(bv: BitVector) -> int:
         # Positive.
         return int(bv)
     # Negative.
-    val = int(AddOne(~(bv[1:])))
+    val = int(add_one(~(bv[1:])))
     if 0 != val:
         return -val
     return -int(bv)
+
+
+signedIntFromBV = signed_int_from_bv  # pylint: disable=invalid-name
 
 
 def ais6tobitvec(str6: str) -> BitVector:
@@ -251,14 +279,16 @@ def ais6tobitvec(str6: str) -> BitVector:
     return bvtotal
 
 
-def bitvectoais6(bv: BitVector, doPadding: bool = True) -> tuple[str, int]:
+def bitvectoais6(
+    bv: BitVector, do_padding: bool = True, **kwargs: Any
+) -> tuple[str, int]:
     """Convert bit vector int an ITU AIS 6 bit string.
 
     Each character represents 6 bits.
 
     Args:
         bv: BitVector, Message bits.
-        doPadding: bool, True if the BitVector should be padded to a multiple of 6.
+        do_padding: bool, True if the BitVector should be padded to a multiple of 6.
 
     Returns:
         A str6 string as represented in a NMEA AIS VDM message and the number of
@@ -267,6 +297,7 @@ def bitvectoais6(bv: BitVector, doPadding: bool = True) -> tuple[str, int]:
     Raises:
         ValueError: The results are not 6-bit aligned.
     """
+    do_padding = kwargs.get("doPadding", do_padding)
     pad = BITS_PER_VDM_CHARACTER - (len(bv) % BITS_PER_VDM_CHARACTER)
     if pad == BITS_PER_VDM_CHARACTER:
         pad = 0
@@ -275,7 +306,7 @@ def bitvectoais6(bv: BitVector, doPadding: bool = True) -> tuple[str, int]:
         str_len += 1
 
     if pad != 0:
-        if doPadding:
+        if do_padding:
             bv += BitVector(size=pad)
         else:
             raise ValueError("Results would not be 6-bit aligned.")

--- a/ais_area_notice/imo_001_22_area_notice.py
+++ b/ais_area_notice/imo_001_22_area_notice.py
@@ -41,14 +41,15 @@ from . import ais_string
 from . import binary
 
 # Track the next value to use for multiline nmea messages.
-next_sequence: int = 1
+NEXT_SEQUENCE: int = 1
+next_sequence: int = NEXT_SEQUENCE  # pylint: disable=invalid-name
 
 # 87 Bits for IMO Circ 289 rather than the 90 for USCG and Nav 55 version.
 SUB_AREA_SIZE: int = 87
 
 # With USCG metadata
 # msg_id is only valid on the first message in a group.
-ais_nmea_regex_str: str = r"""^!(?P<talker>AI)(?P<string_type>VD[MO])
+AIS_NMEA_REGEX_STR: str = r"""^!(?P<talker>AI)(?P<string_type>VD[MO])
 ,(?P<total>\d?)
 ,(?P<sen_num>\d?)
 ,(?P<seq_id>[0-9]?)
@@ -67,10 +68,10 @@ ais_nmea_regex_str: str = r"""^!(?P<talker>AI)(?P<string_type>VD[MO])
 (,(?P<time_stamp>\d+([.]\d+)?))?
 """
 
-ais_nmea_regex: re.Pattern[str] = re.compile(ais_nmea_regex_str, re.VERBOSE)
+ais_nmea_regex: re.Pattern[str] = re.compile(AIS_NMEA_REGEX_STR, re.VERBOSE)
 
 # Beginning of a KML file for visualization.
-kml_head: str = (
+KML_HEAD: str = (
     '<?xml version="1.0" encoding="UTF-8"?>'
     '<kml xmlns="http://www.opengis.net/kml/2.2" '
     'xmlns:gx="http://www.google.com/kml/ext/2.2" '
@@ -78,12 +79,15 @@ kml_head: str = (
     'xmlns:atom="http://www.w3.org/2005/Atom">'
     "<Document>"
 )
+kml_head: str = KML_HEAD  # pylint: disable=invalid-name
 
 # Finish a KML file.
-kml_tail: str = "</Document></kml>"
+KML_TAIL: str = "</Document></kml>"
+kml_tail: str = KML_TAIL  # pylint: disable=invalid-name
 
 # ISO time format for NetworkLinkControl strftime.
-iso8601_timeformat: str = "%Y-%m-%dT%H:%M:%SZ"
+ISO8601_TIMEFORMAT: str = "%Y-%m-%dT%H:%M:%SZ"
+iso8601_timeformat: str = ISO8601_TIMEFORMAT  # pylint: disable=invalid-name
 
 # By name or number.
 notice_type: dict[Any, Any] = {

--- a/ais_area_notice/m366_22.py
+++ b/ais_area_notice/m366_22.py
@@ -40,7 +40,7 @@ class Error(Exception):
 class AreaNoticeSubArea:
     """Base class for subarea shapes in USCG 8:366:22 Area Notices."""
 
-    def getScaleFactor(self, value: float) -> int:
+    def get_scale_factor(self, value: float) -> int:
         """Determine scale factor for a numeric value.
 
         Args:
@@ -57,7 +57,9 @@ class AreaNoticeSubArea:
             return 10
         return 1
 
-    def getScaleFactorRaw(self, scale_factor: int) -> int:
+    getScaleFactor = get_scale_factor
+
+    def get_scale_factor_raw(self, scale_factor: int) -> int:
         """Map scale factor multiplier to 2-bit raw integer encoding.
 
         Args:
@@ -68,7 +70,9 @@ class AreaNoticeSubArea:
         """
         return {1: 0, 10: 1, 100: 2, 1000: 3}[scale_factor]
 
-    def decodeScaleFactor(self, db: an_util.DecodeBits) -> int:
+    getScaleFactorRaw = get_scale_factor_raw
+
+    def decode_scale_factor(self, db: an_util.DecodeBits) -> int:
         """Decode 2-bit raw scale factor from bitstream reader into multiplier.
 
         Args:
@@ -77,8 +81,10 @@ class AreaNoticeSubArea:
         Returns:
             The decoded scale factor multiplier (1, 10, 100, or 1000).
         """
-        scale_factor_raw = db.GetInt(2)
-        return (1, 10, 100, 1000)[scale_factor_raw]
+        scale_factor_raw = db.get_int(2)
+        return {0: 1, 1: 10, 2: 100, 3: 1000}[scale_factor_raw]
+
+    decodeScaleFactor = decode_scale_factor
 
 
 class AreaNoticeCircle(AreaNoticeSubArea):
@@ -114,11 +120,11 @@ class AreaNoticeCircle(AreaNoticeSubArea):
             self.radius = radius
             self.radius_scaled = int(radius / self.scale_factor)
         elif bits is not None:
-            self.DecodeBits(bits)
+            self.decode_bits(bits)
         else:
             raise Error("Must specify bits or parameters.")
 
-    def DecodeBits(self, bits: BitVector) -> None:
+    def decode_bits(self, bits: BitVector) -> None:
         """Unpack circle subarea shape fields from a BitVector.
 
         Args:
@@ -126,16 +132,18 @@ class AreaNoticeCircle(AreaNoticeSubArea):
         """
         logging.info("areanotice CIRCLE - decode bits %d %s", len(bits), bits)
         db = an_util.DecodeBits(bits)
-        self.area_shape = db.GetInt(3)
-        self.scale_factor = self.decodeScaleFactor(db)
-        self.lon = db.GetSignedInt(28) / 600000.0
-        lat_raw = db.GetSignedInt(27)
+        self.area_shape = db.get_int(3)
+        self.scale_factor = self.decode_scale_factor(db)
+        self.lon = db.get_signed_int(28) / 600000.0
+        lat_raw = db.get_signed_int(27)
         self.lat = lat_raw / 600000.0
-        self.precision = db.GetInt(3)
-        self.radius_scaled = db.GetInt(12)
+        self.precision = db.get_int(3)
+        self.radius_scaled = db.get_int(12)
         self.radius = self.radius_scaled * self.scale_factor
-        self.spare = db.GetInt(18)
-        db.Verify(SUB_AREA_BIT_SIZE)
+        self.spare = db.get_int(18)
+        db.verify(SUB_AREA_BIT_SIZE)
+
+    DecodeBits = decode_bits
 
     def get_bits(self) -> BitVector:
         """Pack circle subarea shape fields into a BitVector.
@@ -144,19 +152,19 @@ class AreaNoticeCircle(AreaNoticeSubArea):
             A BitVector containing the encoded circle subarea payload.
         """
         bb = an_util.BuildBits()
-        bb.AddUInt(SHAPES["CIRCLE"], 3)
+        bb.add_uint(SHAPES["CIRCLE"], 3)
         if "scale_factor" not in self.__dict__:
-            self.scale_factor = self.getScaleFactor(self.radius)
-        bb.AddUInt(self.getScaleFactorRaw(self.scale_factor), 2)
+            self.scale_factor = self.get_scale_factor(self.radius)
+        bb.add_uint(self.get_scale_factor_raw(self.scale_factor), 2)
         assert self.lon is not None and self.lat is not None
-        bb.AddInt(round(self.lon * 600000), 28)
+        bb.add_int(round(self.lon * 600000), 28)
         # TODO(schwehr): Do we round all before encoding?
-        bb.AddInt(round(self.lat * 600000), 27)
-        bb.AddUInt(self.precision, 3)
-        bb.AddUInt(int(self.radius / self.scale_factor), 12)
-        bb.AddUInt(0, 18)
-        bb.Verify(SUB_AREA_BIT_SIZE)
-        return bb.GetBits()
+        bb.add_int(round(self.lat * 600000), 27)
+        bb.add_uint(self.precision, 3)
+        bb.add_uint(int(self.radius / self.scale_factor), 12)
+        bb.add_uint(0, 18)
+        bb.verify(SUB_AREA_BIT_SIZE)
+        return bb.get_bits()
 
 
 class AreaNotice:
@@ -256,10 +264,10 @@ class AreaNotice:
             if fill_bits:
                 bv = bv[:-fill_bits]
             bits_list.append(bv)
-        bits = binary.joinBV(bits_list)
-        self.DecodeBits(bits)
+        bits = binary.join_bv(bits_list)
+        self.decode_bits(bits)
 
-    def DecodeBits(self, bits: BitVector) -> None:
+    def decode_bits(self, bits: BitVector) -> None:
         """Unpack Area Notice fields from a BitVector payload.
 
         Args:
@@ -269,26 +277,26 @@ class AreaNotice:
             Error: If message headers or subarea counts are invalid.
         """
         db = an_util.DecodeBits(bits)
-        self.message_id = db.GetInt(6)
-        self.repeat_indicator = db.GetInt(2)
-        self.mmsi = db.GetInt(30)
-        self.spare = db.GetInt(2)
-        self.dac = db.GetInt(10)
-        self.fi = db.GetInt(6)
-        db.Verify(56)
-        self.link_id = db.GetInt(10)
-        self.area_type = db.GetInt(7)
-        month = db.GetInt(4)  # UTC
-        day = db.GetInt(5)
-        hour = db.GetInt(5)
-        minute = db.GetInt(6)
+        self.message_id = db.get_int(6)
+        self.repeat_indicator = db.get_int(2)
+        self.mmsi = db.get_int(30)
+        self.spare = db.get_int(2)
+        self.dac = db.get_int(10)
+        self.fi = db.get_int(6)
+        db.verify(56)
+        self.link_id = db.get_int(10)
+        self.area_type = db.get_int(7)
+        month = db.get_int(4)  # UTC
+        day = db.get_int(5)
+        hour = db.get_int(5)
+        minute = db.get_int(6)
         # TODO(schwehr): Handle year boundary.
         now = datetime.datetime.utcnow()
         self.when = datetime.datetime(now.year, month, day, hour, minute)
-        self.duration_min = db.GetInt(18)
+        self.duration_min = db.get_int(18)
         # self.spare2 = db.GetInt(3)
         start_sub_areas = 111
-        db.Verify(start_sub_areas)
+        db.verify(start_sub_areas)
 
         sub_areas_bits = bits[start_sub_areas:]
         num_sub_areas = len(sub_areas_bits) // SUB_AREA_BIT_SIZE
@@ -304,10 +312,12 @@ class AreaNotice:
             end = start + SUB_AREA_BIT_SIZE
             sub_bits = sub_areas_bits[start:end]
             logging.info("bits for sub area: %d %d %d", len(sub_bits), start, end)
-            subarea = self.SubareaFactory(sub_bits)
+            subarea = self.subarea_factory(sub_bits)
             self.add_subarea(subarea)
 
-    def SubareaFactory(self, bits: BitVector) -> AreaNoticeSubArea:
+    DecodeBits = decode_bits
+
+    def subarea_factory(self, bits: BitVector) -> AreaNoticeSubArea:
         """Instantiate appropriate subarea shape object from raw bit slice.
 
         Args:
@@ -344,3 +354,5 @@ class AreaNotice:
         if shape == 5:
             return AreaNoticeText(bits=bits)  # type: ignore[name-defined]
         raise Error(f"Unsupported area shape: {shape}")
+
+    SubareaFactory = subarea_factory

--- a/ais_area_notice/m367_22.py
+++ b/ais_area_notice/m367_22.py
@@ -47,8 +47,8 @@ class DecodeBits:
         self.bits = bits
         self.pos = 0
 
-    # TODO(schwehr): This should be GetUInt.
-    def GetInt(self, length: int) -> int:
+    # TODO(schwehr): This should be get_uint.
+    def get_int(self, length: int) -> int:
         """Read an unsigned integer of specified bit length from the bitstream.
 
         Args:
@@ -62,8 +62,10 @@ class DecodeBits:
         self.pos += length
         return value
 
-    # TODO(schwehr): This should be GetInt.
-    def GetSignedInt(self, length: int) -> int:
+    GetInt = get_int
+
+    # TODO(schwehr): This should be get_int.
+    def get_signed_int(self, length: int) -> int:
         """Read a signed integer of specified bit length from the bitstream.
 
         Args:
@@ -73,11 +75,13 @@ class DecodeBits:
             The signed integer value decoded from the bit slice.
         """
         end = self.pos + length
-        value = binary.signedIntFromBV(self.bits[self.pos : end])
+        value = binary.signed_int_from_bv(self.bits[self.pos : end])
         self.pos += length
         return value
 
-    def GetText(self, length: int, strip: bool = True) -> str:
+    GetSignedInt = get_signed_int
+
+    def get_text(self, length: int, strip: bool = True) -> str:
         """Read 6-bit AIS character text of specified bit length from the bitstream.
 
         Args:
@@ -89,14 +93,16 @@ class DecodeBits:
         """
         assert length % 6 == 0
         end = self.pos + length
-        text = ais_string.Decode(self.bits[self.pos : end])
+        text = ais_string.decode(self.bits[self.pos : end])
         at = text.find("@")
         if strip and at != -1:
             text = text[:at]
         self.pos += length
         return text
 
-    def Verify(self, offset: int) -> None:
+    GetText = get_text
+
+    def verify(self, offset: int) -> None:
         """Verify that current bit read position matches the expected offset.
 
         Args:
@@ -105,6 +111,8 @@ class DecodeBits:
         if self.pos != offset:
             logging.info("DecodeBits FAILING!  expect: %s got: %s", offset, self.pos)
         assert self.pos == offset
+
+    Verify = verify
 
 
 class BuildBits:
@@ -122,21 +130,25 @@ class BuildBits:
         self.bv_list = []
         self.bits_expected = 0
 
-    def AddUInt(self, val: int, num_bits: int) -> None:
+    def add_uint(self, val: int, num_bits: int) -> None:
         """Add an unsigned integer."""
-        bits = binary.setBitVectorSize(BitVector.from_int(val), num_bits)
+        bits = binary.set_bit_vector_size(BitVector.from_int(val), num_bits)
         assert num_bits == len(bits)
         self.bits_expected += num_bits
         self.bv_list.append(bits)
 
-    def AddInt(self, val: int | float, num_bits: int) -> None:
+    AddUInt = add_uint
+
+    def add_int(self, val: int | float, num_bits: int) -> None:
         """Add a signed integer."""
-        bits = binary.bvFromSignedInt(int(val), num_bits)
+        bits = binary.bv_from_signed_int(int(val), num_bits)
         assert num_bits == len(bits)
         self.bits_expected += num_bits
         self.bv_list.append(bits)
 
-    def AddText(self, val: str, num_bits: int) -> None:
+    AddInt = add_int
+
+    def add_text(self, val: str, num_bits: int) -> None:
         """Add 6-bit AIS encoded text of specified bit length to the bitstream.
 
         Args:
@@ -146,11 +158,13 @@ class BuildBits:
         num_char = num_bits // 6
         assert num_bits % 6 == 0
         text = val.ljust(num_char, "@")
-        bits = ais_string.Encode(text)
+        bits = ais_string.encode(text)
         self.bits_expected += num_bits
         self.bv_list.append(bits)
 
-    def Verify(self, num_bits: int) -> None:
+    AddText = add_text
+
+    def verify(self, num_bits: int) -> None:
         """Verify that total packed bits match expected bit count.
 
         Args:
@@ -158,15 +172,19 @@ class BuildBits:
         """
         assert self.bits_expected == num_bits
 
-    def GetBits(self) -> BitVector:
+    Verify = verify
+
+    def get_bits(self) -> BitVector:
         """Concatenate all bit vectors in the list into a single BitVector.
 
         Returns:
             The combined BitVector.
         """
-        bits = binary.joinBV(self.bv_list)
+        bits = binary.join_bv(self.bv_list)
         assert len(bits) == self.bits_expected
         return bits
+
+    GetBits = get_bits
 
 
 # TODO(schwehr): Should this import from 1:22?
@@ -181,7 +199,7 @@ class AreaNoticeSubArea:
     e_dim_scaled: int = 0
     n_dim_scaled: int = 0
 
-    def getScaleFactor(self, value: float) -> int:
+    def get_scale_factor(self, value: float) -> int:
         """The scale factor value for the network."""
         if value / 100.0 >= 4095:
             return 1000
@@ -191,11 +209,15 @@ class AreaNoticeSubArea:
             return 10
         return 1
 
-    def getScaleFactorRaw(self, scale_factor: int) -> int:
+    getScaleFactor = get_scale_factor
+
+    def get_scale_factor_raw(self, scale_factor: int) -> int:
         """Given a scale factor, give the value to be sent over the network."""
         return {1: 0, 10: 1, 100: 2, 1000: 3}[scale_factor]
 
-    def decodeScaleFactor(self, db: DecodeBits) -> int:
+    getScaleFactorRaw = get_scale_factor_raw
+
+    def decode_scale_factor(self, db: DecodeBits) -> int:
         """Decode 2-bit raw scale factor from bitstream reader into multiplier.
 
         Args:
@@ -204,8 +226,10 @@ class AreaNoticeSubArea:
         Returns:
             The decoded scale factor multiplier (1, 10, 100, or 1000).
         """
-        scale_factor_raw = db.GetInt(2)
+        scale_factor_raw = db.get_int(2)
         return (1, 10, 100, 1000)[scale_factor_raw]
+
+    decodeScaleFactor = decode_scale_factor
 
     def get_bits(self) -> BitVector:
         """Pack subarea shape fields into a BitVector.

--- a/tests/imo_001_22_area_notice_test.py
+++ b/tests/imo_001_22_area_notice_test.py
@@ -84,7 +84,7 @@ def assert_almost_equal_geojson(
 class TestRegex:
     """Test NMEA sentence regular expression parsing."""
 
-    def testWithoutMetadata(self) -> None:
+    def test_without_metadata(self) -> None:
         """Test parsing NMEA sentence without metadata header."""
         msg_str = "!AIVDM,1,1,,A,E>b6Kpiacg`0aagRW:JJropqKLpLkD6D8AB;000000VP20,4*4C"
         match = area_notice.ais_nmea_regex.search(msg_str)
@@ -101,7 +101,7 @@ class TestRegex:
         assert result["fill_bits"] == "4"
         assert result["checksum"] == "4C"
 
-    def testWithSimpleMetadata(self) -> None:
+    def test_with_simple_metadata(self) -> None:
         """Test parsing NMEA sentence with simple station and timestamp metadata."""
         msg_str = (
             "!AIVDM,1,1,,B,15N8ac?P00ISgOBA4VU:lOv028Rq,0*4A,b003669953,1297555217"
@@ -122,7 +122,7 @@ class TestRegex:
         assert result["station"] == "b003669953"
         assert result["time_stamp"] == "1297555217"
 
-    def testWithMetadata(self) -> None:
+    def test_with_metadata(self) -> None:
         """Test parsing NMEA sentence with full receiver metadata."""
         msg_str = (
             # pylint: disable=line-too-long
@@ -149,7 +149,7 @@ class TestRegex:
         assert result["station_type"] == "r"
         assert result["time_stamp"] == "1297584148"
 
-    def testWithX(self) -> None:
+    def test_with_x(self) -> None:
         """Test parsing NMEA sentence with extended station metadata fields."""
         msg_str = (
             # pylint: disable=line-too-long
@@ -175,7 +175,7 @@ class TestRegex:
         assert result["station"] == "r003669976"
         assert result["time_stamp"] == "1166058609"
 
-    def testMultiLine1(self) -> None:
+    def test_multi_line1(self) -> None:
         """Test parsing first sentence of multi-line NMEA message."""
         msg_str = (
             # pylint: disable=line-too-long
@@ -192,7 +192,7 @@ class TestRegex:
         assert result["chan"] == "B"
         assert result["msg_id"] == "5"
 
-    def testMultiLine2(self) -> None:
+    def test_multi_line2(self) -> None:
         """Test parsing second sentence of multi-line NMEA message."""
         msg_str = "!AIVDM,2,2,6,B,000000000000000,2*21,b003669705,1297584166"
         match = area_notice.ais_nmea_regex.search(msg_str)
@@ -205,7 +205,7 @@ class TestRegex:
         assert result["seq_id"] == "6"
         assert result["chan"] == "B"
 
-    def testOwnShip(self) -> None:
+    def test_own_ship(self) -> None:
         """Test parsing AIVDO own-ship sentence."""
         msg_str = "!AIVDO,1,1,,,13tfD@?P7BJsWhhHb5eBtwwL0000,0*05,rnhjel,1297555200.32"
         match = area_notice.ais_nmea_regex.search(msg_str)
@@ -223,7 +223,7 @@ class TestRegex:
 class Test0Math:
     """Test vector rotation math helpers."""
 
-    def testRotate(self) -> None:
+    def test_rotate(self) -> None:
         """Test rotating origin point vector."""
         # Rotate about 0.
         p1 = (0.0, 0.0)
@@ -233,7 +233,7 @@ class Test0Math:
         assert (0, 0) == area_notice.vec_rot(p1, math.pi / 4)
         assert (0, 0) == area_notice.vec_rot(p1, -math.pi / 4)
 
-    def testRotate2(self) -> None:
+    def test_rotate2(self) -> None:
         """Test rotating unit X vector by various angles."""
         # Rotate of 1, 0.
         p1 = (1.0, 0.0)
@@ -256,7 +256,7 @@ class Test0Math:
             (0, 1), area_notice.vec_rot([math.sqrt(0.5)] * 2, PI_4)
         )
 
-    def testRotate3(self) -> None:
+    def test_rotate3(self) -> None:
         """Test rotating unit Y vector by various angles."""
         # Rotate of 0, 1.
         p1 = (0.0, 1.0)
@@ -280,7 +280,7 @@ class Test0Math:
 class Test1AIVDM:
     """Test AIVDM sentence generator base class."""
 
-    def testAivdm(self) -> None:
+    def test_aivdm(self) -> None:
         """Test AIVDM sentence generator raises exception when mandatory fields missing."""
         a = area_notice.AIVDM()
         with pytest.raises(area_notice.AisPackingException):
@@ -299,7 +299,7 @@ class Test1AIVDM:
 class Test3AreaNoticeCirclePt:
     """Test circle/point subarea geometry and bit packing."""
 
-    def testCircleGeom(self) -> None:
+    def test_circle_geom(self) -> None:
         """Test point and circle Shapely geometry generation."""
         pt1 = area_notice.AreaNoticeCirclePt(-73, 43, 0)
         assert pt1.radius == 0
@@ -309,7 +309,7 @@ class Test3AreaNoticeCirclePt:
         pt2 = area_notice.AreaNoticeCirclePt(-73, 43, 123.4)
         assert len(pt2.geom().boundary.coords) > 10
 
-    def testSelfConsistant(self) -> None:
+    def test_self_consistent(self) -> None:
         """Test AreaNoticeCirclePt bit packing and unpacking round-trip consistency."""
         pt0 = area_notice.AreaNoticeCirclePt(-73, 43, 0)
         pt1 = area_notice.AreaNoticeCirclePt(bits=pt0.get_bits())
@@ -328,7 +328,7 @@ class Test3AreaNoticeCirclePt:
 class Test5AreaNoticeSimple:
     """Test simple Area Notice message encoding and visualization."""
 
-    def testSimple(self) -> None:
+    def test_simple(self) -> None:
         """Test basic Area Notice bitstream generation with options."""
         an1 = area_notice.AreaNotice(0, datetime.datetime.utcnow(), 100)
         assert len(an1.get_bits()) == 2 + 16 + 10 + 7 + 4 + 5 + 5 + 6 + 18
@@ -348,7 +348,7 @@ class Test5AreaNoticeSimple:
 
         assert len(an1.get_bbm()) == 1
 
-    def testWhale(self) -> None:
+    def test_whale(self) -> None:
         """Test building Area Notice for whale safety subareas."""
         no_whales = area_notice.AreaNotice(
             area_notice.notice_type["cau_mammals_not_obs"],
@@ -363,7 +363,7 @@ class Test5AreaNoticeSimple:
         no_whales.add_subarea(area_notice.AreaNoticeCirclePt(-69, 42, radius=9260))
         no_whales.add_subarea(area_notice.AreaNoticeCirclePt(-68, 43, radius=9260))
 
-    def testCircleSubareaJson(self) -> None:
+    def test_circle_subarea_json(self) -> None:
         """Test GeoJSON export for circle and point subareas."""
         area = area_notice.AreaNoticeCirclePt(-69.849541, 42.0792730, radius=9260)
         assert len(area.__geo_interface__["geometry"]["coordinates"]) > 5
@@ -371,7 +371,7 @@ class Test5AreaNoticeSimple:
         area = area_notice.AreaNoticeCirclePt(-69.849541, 42.0792730, radius=0)
         assert len(area.__geo_interface__["geometry"]["coordinates"]) == 2
 
-    def testHtml(self) -> None:
+    def test_html(self) -> None:
         """Test HTML rendering of Area Notice."""
         whales = area_notice.AreaNotice(
             area_notice.notice_type["cau_mammals_reduce_speed"],
@@ -385,7 +385,7 @@ class Test5AreaNoticeSimple:
         whales.add_subarea(area_notice.AreaNoticeCirclePt(-69.8, 42.07, radius=0))
         # TODO(schwehr): Write the test.
 
-    def testKml(self) -> None:
+    def test_kml(self) -> None:
         """Test KML markup generation for Area Notice."""
         whales = area_notice.AreaNotice(
             area_notice.notice_type["cau_mammals_reduce_speed"],
@@ -406,7 +406,7 @@ class Test5AreaNoticeSimple:
 class TestBitDecoding:
     """Test Area Notice bit decoding for point subareas."""
 
-    def testPoint(self) -> None:
+    def test_point(self) -> None:
         """Test Area Notice encoding and decoding roundtrip for point subarea."""
         year = datetime.datetime.utcnow().year
         pt1 = area_notice.AreaNotice(
@@ -427,7 +427,7 @@ class TestBitDecoding:
 
         assert_almost_equal_geojson(orig, decoded)
 
-    def testCircle(self) -> None:
+    def test_circle(self) -> None:
         """Test Area Notice encoding and decoding roundtrip for circle subarea."""
         now = datetime.datetime.utcnow()
         circle1 = area_notice.AreaNotice(
@@ -448,7 +448,7 @@ class TestBitDecoding:
 
         assert_almost_equal_geojson(orig, decoded)
 
-    def testRectangle(self) -> None:
+    def test_rectangle(self) -> None:
         """Test Area Notice encoding and decoding roundtrip for rectangle subarea."""
         rect = area_notice.AreaNotice(
             area_notice.notice_type["cau_mammals_reduce_speed"],
@@ -465,7 +465,7 @@ class TestBitDecoding:
         )
         assert_almost_equal_geojson(orig, decoded)
 
-    def testSector(self) -> None:
+    def test_sector(self) -> None:
         """Test Area Notice encoding and decoding roundtrip for sector subarea."""
         sec1 = area_notice.AreaNotice(
             area_notice.notice_type["cau_habitat_reduce_speed"],
@@ -481,7 +481,7 @@ class TestBitDecoding:
         )
         assert_almost_equal_geojson(orig, decoded)
 
-    def testLine(self) -> None:
+    def test_line(self) -> None:
         """Test Area Notice encoding and decoding roundtrip for polyline subarea."""
         line1 = area_notice.AreaNotice(
             area_notice.notice_type["report_of_icing"],
@@ -496,7 +496,7 @@ class TestBitDecoding:
         decoded = geojson.loads(geojson.dumps(line2))
         assert_almost_equal_geojson(orig, decoded)
 
-    def testPolygon(self) -> None:
+    def test_polygon(self) -> None:
         """Test Area Notice encoding and decoding roundtrip for polygon subarea."""
         poly1 = area_notice.AreaNotice(
             area_notice.notice_type["cau_divers"],
@@ -513,7 +513,7 @@ class TestBitDecoding:
         decoded = geojson.loads(geojson.dumps(poly2))
         assert_almost_equal_geojson(orig, decoded)
 
-    def testFreeText(self) -> None:
+    def test_free_text(self) -> None:
         """Test Area Notice encoding and decoding roundtrip for free text subarea."""
         text1 = area_notice.AreaNotice(
             area_notice.notice_type["res_military_ops"],
@@ -535,7 +535,7 @@ class TestBitDecoding:
 class TestBitDecoding2:
     """Test Area Notice bit decoding for complex mixed subareas."""
 
-    def testPoint(self) -> None:
+    def test_point(self) -> None:
         """Test Area Notice with one subarea of every shape type."""
         # One of each.
         notice = area_notice.AreaNotice(
@@ -566,7 +566,7 @@ class TestBitDecoding2:
         )
         assert_almost_equal_geojson(orig, decoded)
 
-    def testManySectors(self) -> None:
+    def test_many_sectors(self) -> None:
         """Test Area Notice with multiple sector subareas and max subarea limit."""
         notice = area_notice.AreaNotice(
             area_notice.notice_type["cau_mammals_not_obs"],
@@ -613,7 +613,7 @@ class TestBitDecoding2:
                 area_notice.AreaNoticeSector(-69.8, 39.5, 9000, 220, 290)
             )
 
-    def testFullText(self) -> None:
+    def test_full_text(self) -> None:
         """Test Area Notice with multi-part text subareas and merged text retrieval."""
         notice = area_notice.AreaNotice(
             area_notice.notice_type["cau_mammals_not_obs"],
@@ -651,7 +651,7 @@ class TestLineTools:
     """Check going from lon, lat pairs to angle, distance pairs."""
 
     @pytest.mark.skip(reason="TODO(schwehr): Fix this failure.")
-    def testOneSegmentCardinal(self) -> None:
+    def test_one_segment_cardinal(self) -> None:
         """Test converting lon/lat segments to polyline angle and distance offsets."""
         p0 = (0.0, 0.0)
 
@@ -682,7 +682,7 @@ class TestLineTools:
 class TestWhaleNotices:
     """Make sure the whale notices works correctly."""
 
-    def testNoWhales(self) -> None:
+    def test_no_whales(self) -> None:
         """Test Area Notice for cautionary no whales observed zone."""
         zone_type = area_notice.notice_type["cau_mammals_not_obs"]
         circle = area_notice.AreaNotice(
@@ -718,7 +718,7 @@ class TestWhaleNotices:
         assert data["bbm"]["area_type_desc"] == area_notice.notice_type[zone_type]
         # TODO(schwehr): Verify other parameters like the location and times.
 
-    def testWhalesObservedCircleNotice(self) -> None:
+    def test_whales_observed_circle_notice(self) -> None:
         """Test Area Notice for mandatory whale speed reduction circle zone."""
         zone_type = area_notice.notice_type["cau_mammals_reduce_speed"]
         circle = area_notice.AreaNotice(

--- a/tests/imo_001_26_environment_test.py
+++ b/tests/imo_001_26_environment_test.py
@@ -374,7 +374,7 @@ class TestSensorReports:
         self.hour = now.hour
         self.minute = now.minute
 
-    def test_SensorReport(self) -> None:
+    def test_sensor_report(self) -> None:
         """Test base SensorReport initialization, header bit length, and date calculation."""
         # Create and work with just the parent class.
         report_type = 0
@@ -426,7 +426,7 @@ class TestSensorReports:
         )
         assert sr.get_date() == datetime.datetime(2011, 12, 31, 23, 59)
 
-    def test_Sr_eq(self) -> None:
+    def test_sr_eq(self) -> None:
         """SensorReport equality operator"""
         sr_0 = env.SensorReport(0, 2010, 1, 1, 1, 1, site_id=0)
         sr_0b = env.SensorReport(bits=sr_0.get_bits())
@@ -444,13 +444,13 @@ class TestSensorReports:
         assert sr_1 == sr_1  # pylint: disable=comparison-with-itself
         assert sr_0 != sr_1
 
-    def test_Sr_not_eq(self) -> None:
+    def test_sr_not_eq(self) -> None:
         """Test SensorReport inequality for differing site IDs."""
         sr_0 = env.SensorReport(0, 2010, 1, 1, 1, 1, site_id=0)
         sr_1 = env.SensorReport(0, 2010, 1, 1, 1, 1, site_id=1)
         assert sr_0 != sr_1
 
-    def test_SrLocation(self) -> None:
+    def test_sr_location(self) -> None:
         """SensorReportLocation"""
         site_id = int(math.floor(random.random() * 128))
         sr_l = env.SensorReportLocation(day=1, hour=2, minute=3, site_id=site_id)
@@ -460,7 +460,7 @@ class TestSensorReports:
         assert sr_l == sr_l2
         assert sr_l != env.SensorReport(0, site_id=0)
 
-    def test_SrLocation_min(self) -> None:
+    def test_sr_location_min(self) -> None:
         """SrLocation minimum values"""
         sr_l = env.SensorReportLocation(
             year=2010,
@@ -478,7 +478,7 @@ class TestSensorReports:
         sr_lb = env.SensorReportLocation(bits=sr_l.get_bits())
         assert sr_l == sr_lb
 
-    def test_SrLocation_max(self) -> None:
+    def test_sr_location_max(self) -> None:
         """SrLocation maximum values"""
         sr_l = env.SensorReportLocation(
             year=2049,
@@ -506,7 +506,7 @@ class TestSensorReports:
 
         assert sr_l == sr_lb
 
-    def test_SrLoc_fuzz(self) -> None:
+    def test_sr_loc_fuzz(self) -> None:
         """Fuzz test SensorReportLocation bit stream roundtrip."""
         for _ in range(FUZZ_COUNT):
             sr = random_loc()
@@ -517,7 +517,7 @@ class TestSensorReports:
                 sys.stderr.write("  " + str(sr_b) + "\n")
             assert sr == sr_b
 
-    def test_SrId(self) -> None:
+    def test_sr_id(self) -> None:
         """SensorReportId with range of strings."""
         site_id = int(math.floor(random.random() * 128))
         sr = env.SensorReportId(site_id=site_id)
@@ -536,7 +536,7 @@ class TestSensorReports:
         assert " id" in s2
         assert s1 == s2
 
-    def test_SrId_fuzz(self) -> None:
+    def test_sr_id_fuzz(self) -> None:
         """Fuzz test SensorReportId bit stream roundtrip."""
         for _ in range(FUZZ_COUNT):
             sr = random_id()
@@ -555,7 +555,7 @@ class TestSensorReports:
         assert sr.id_str == id_str.ljust(14, "@")
         assert sr == sr_b
 
-    def test_SrWind(self) -> None:
+    def test_sr_wind(self) -> None:
         """SensorReport Wind"""
         site_id = int(math.floor(random.random() * 128))
         sr = env.SensorReportWind(site_id=site_id)
@@ -570,7 +570,7 @@ class TestSensorReports:
         assert sr.data_descr == 7
         assert env.SensorReportWind(bits=sr.get_bits()).data_descr == 7
 
-    def test_SrWind_min(self) -> None:
+    def test_sr_wind_min(self) -> None:
         """SensorReport Wind minimum valid values"""
         sr = env.SensorReportWind(
             year=2020,
@@ -614,7 +614,7 @@ class TestSensorReports:
         assert sr_b.forecast_minute == 0
         assert sr_b.duration_min == 1
 
-    def test_SrWind_max(self) -> None:
+    def test_sr_wind_max(self) -> None:
         """SensorReport Wind minimum valid values"""
         sr = env.SensorReportWind(
             year=2018,
@@ -655,7 +655,7 @@ class TestSensorReports:
         assert sr_b.forecast_minute == 59
         assert sr_b.duration_min == 255
 
-    def test_SrWind_fuzz(self) -> None:
+    def test_sr_wind_fuzz(self) -> None:
         """Fuzz test SensorReportWind bit stream roundtrip."""
         for _ in range(FUZZ_COUNT):
             sr = random_wind()
@@ -666,7 +666,7 @@ class TestSensorReports:
                 sys.stderr.write("  " + str(sr_b) + "\n")
             assert sr == sr_b
 
-    def test_SrWaterLevel(self) -> None:
+    def test_sr_water_level(self) -> None:
         """SensorReport WaterLevel"""
         site_id = int(math.floor(random.random() * 128))
         sr = env.SensorReportWaterLevel(site_id=site_id)
@@ -682,7 +682,7 @@ class TestSensorReports:
         description = env.SensorReportWaterLevel(bits=sr.get_bits()).data_descr
         assert description == 7
 
-    def test_SrWaterLevel_min(self) -> None:
+    def test_sr_water_level_min(self) -> None:
         """SensorReport WaterLevel minimum"""
         sr = env.SensorReportWaterLevel(
             year=2010,
@@ -721,7 +721,7 @@ class TestSensorReports:
         assert sr_b.forecast_minute == 0
         assert sr_b.duration_min == 0
 
-    def test_SrWaterLevel_max(self) -> None:
+    def test_sr_water_level_max(self) -> None:
         """SensorReport WaterLevel maximum"""
         sr = env.SensorReportWaterLevel(
             year=2049,
@@ -760,7 +760,7 @@ class TestSensorReports:
         assert sr_b.forecast_minute == 59
         assert sr_b.duration_min == 255
 
-    def test_SrWaterLevel_fuzz(self) -> None:
+    def test_sr_water_level_fuzz(self) -> None:
         """Fuzz test SensorReportWaterLevel bit stream roundtrip."""
         for _ in range(FUZZ_COUNT):
             sr = random_waterlevel()
@@ -771,7 +771,7 @@ class TestSensorReports:
                 sys.stderr.write("  " + str(sr_b) + "\n")
             assert sr == sr_b
 
-    def test_SensorReportCurrent2d(self) -> None:
+    def test_sensor_report_current_2d(self) -> None:
         """SensorReport Current2d"""
         site_id = int(math.floor(random.random() * 128))
         sr = env.SensorReportCurrent2d(site_id=site_id)
@@ -787,7 +787,7 @@ class TestSensorReports:
         description = env.SensorReportCurrent2d(bits=sr.get_bits()).data_descr
         assert description == 7
 
-    def test_SensorReportCurrent2d_min(self) -> None:
+    def test_sensor_report_current_2d_min(self) -> None:
         """SensorReport Current2d minimum"""
         sr = env.SensorReportCurrent2d(
             year=2010,
@@ -815,7 +815,7 @@ class TestSensorReports:
             assert cur["level"] == pytest.approx(0)
         assert sr_b.data_descr == 0
 
-    def test_SensorReportCurrent2d_max(self) -> None:
+    def test_sensor_report_current_2d_max(self) -> None:
         """SensorReport Current2d maximum"""
         sr = env.SensorReportCurrent2d(
             year=2049,
@@ -843,7 +843,7 @@ class TestSensorReports:
             assert cur["level"] == pytest.approx(361)
         assert sr_b.data_descr == 5
 
-    def test_SrCurrent2d_fuzz(self) -> None:
+    def test_sr_current_2d_fuzz(self) -> None:
         """Fuzz test SensorReportCurrent2d bit stream roundtrip."""
         for _ in range(FUZZ_COUNT):
             sr = random_current2d()
@@ -854,7 +854,7 @@ class TestSensorReports:
                 sys.stderr.write("  " + str(sr_b) + "\n")
             assert sr == sr_b
 
-    def test_SensorReportCurrent3d(self) -> None:
+    def test_sensor_report_current_3d(self) -> None:
         """SensorReport Current3d"""
         site_id = int(math.floor(random.random() * 128))
         sr = env.SensorReportCurrent3d(site_id=site_id)
@@ -864,7 +864,7 @@ class TestSensorReports:
         sr_b = env.SensorReportCurrent3d(bits=sr.get_bits())
         assert sr == sr_b
 
-    def test_SensorReportCurrent3d_min(self) -> None:
+    def test_sensor_report_current_3d_min(self) -> None:
         """SensorReport Current3d minimum"""
         sr = env.SensorReportCurrent3d(
             year=2010,
@@ -891,7 +891,7 @@ class TestSensorReports:
                 assert cur[x] == pytest.approx(0.0)
         assert sr_b.data_descr == 0
 
-    def test_SensorReportCurrent3d_max(self) -> None:
+    def test_sensor_report_current_3d_max(self) -> None:
         """SensorReport Current3d maximum"""
         sr = env.SensorReportCurrent3d(
             year=2010,
@@ -918,7 +918,7 @@ class TestSensorReports:
                 assert cur[x] == pytest.approx(24.6)
         assert sr_b.data_descr == 0
 
-    def test_SrCurrent3d_fuzz(self) -> None:
+    def test_sr_current_3d_fuzz(self) -> None:
         """Fuzz test SensorReportCurrent3d bit stream roundtrip."""
         for _ in range(FUZZ_COUNT):
             sr = random_current3d()
@@ -929,7 +929,7 @@ class TestSensorReports:
                 sys.stderr.write("  " + str(sr_b) + "\n")
             assert sr == sr_b
 
-    def test_SensorReportCurrentHorz(self) -> None:
+    def test_sensor_report_current_horz(self) -> None:
         """SensorReport CurrentHorz"""
         site_id = int(math.floor(random.random() * 128))
         sr = env.SensorReportCurrentHorz(site_id=site_id)
@@ -940,7 +940,7 @@ class TestSensorReports:
 
         assert sr == sr_b
 
-    def test_SensorReportCurrentHorz_min(self) -> None:
+    def test_sensor_report_current_horz_min(self) -> None:
         """SensorReport CurrentHorz minimum"""
         sr = env.SensorReportCurrentHorz(
             year=2010,
@@ -966,7 +966,7 @@ class TestSensorReports:
             for val in cur.values():
                 assert val == pytest.approx(0.0)
 
-    def test_SensorReportCurrentHorz_max(self) -> None:
+    def test_sensor_report_current_horz_max(self) -> None:
         """SensorReport CurrentHorz maximum"""
         sr = env.SensorReportCurrentHorz(
             year=2010,
@@ -994,7 +994,7 @@ class TestSensorReports:
             assert cur["dist"] == 121
             assert cur["level"] == 361
 
-    def test_SrCurrentHorz_fuzz(self) -> None:
+    def test_sr_current_horz_fuzz(self) -> None:
         """Fuzz test SensorReportCurrentHorz bit stream roundtrip."""
         for _ in range(FUZZ_COUNT):
             sr = random_currenthorz()
@@ -1005,7 +1005,7 @@ class TestSensorReports:
                 sys.stderr.write("  " + str(sr_b) + "\n")
             assert sr == sr_b
 
-    def test_SensorReportSeaState(self) -> None:
+    def test_sensor_report_sea_state(self) -> None:
         """SensorReport SeaState"""
         site_id = int(math.floor(random.random() * 128))
         sr = env.SensorReportSeaState(site_id=site_id)
@@ -1014,7 +1014,7 @@ class TestSensorReports:
         assert sr.month == 1
         env.SensorReportSeaState(bits=sr.get_bits())
 
-    def test_SensorReportSeaState_min(self) -> None:
+    def test_sensor_report_sea_state_min(self) -> None:
         """SensorReport SeaState minimum"""
         sr = env.SensorReportSeaState(
             year=2010,
@@ -1053,7 +1053,7 @@ class TestSensorReports:
         assert sr_b.wave_data_descr == pytest.approx(1)
         assert sr_b.salinity == pytest.approx(0)
 
-    def test_SensorReportSeaState_max(self) -> None:
+    def test_sensor_report_sea_state_max(self) -> None:
         """SensorReport SeaState max"""
         sr = env.SensorReportSeaState(
             year=2010,
@@ -1091,7 +1091,7 @@ class TestSensorReports:
         assert sr_b.wave_data_descr == 5
         assert sr_b.salinity == pytest.approx(50.0)
 
-    def test_SrCurrentSeaState_fuzz(self) -> None:
+    def test_sr_current_sea_state_fuzz(self) -> None:
         """Fuzz test SensorReportSeaState bit stream roundtrip."""
         for _ in range(FUZZ_COUNT):
             sr = random_seastate()
@@ -1102,7 +1102,7 @@ class TestSensorReports:
                 sys.stderr.write("  " + str(sr_b) + "\n")
             assert sr == sr_b
 
-    def test_SensorReportSalinity(self) -> None:
+    def test_sensor_report_salinity(self) -> None:
         """SensorReport Salinity"""
         site_id = int(math.floor(random.random() * 128))
         sr = env.SensorReportSalinity(site_id=site_id)
@@ -1111,7 +1111,7 @@ class TestSensorReports:
         assert sr.month == 1
         env.SensorReportSalinity(bits=sr.get_bits())
 
-    def test_SensorReportSalinity_min(self) -> None:
+    def test_sensor_report_salinity_min(self) -> None:
         """SensorReport Salinity minimum"""
         sr = env.SensorReportSalinity(
             year=2010,
@@ -1135,7 +1135,7 @@ class TestSensorReports:
         assert sr_b.salinity_type == 0
         assert sr_b.data_descr == 1
 
-    def test_SensorReportSalinity_max(self) -> None:
+    def test_sensor_report_salinity_max(self) -> None:
         """SensorReport Salinity maximum"""
         sr = env.SensorReportSalinity(
             year=2010,
@@ -1159,7 +1159,7 @@ class TestSensorReports:
         assert sr_b.salinity_type == 2
         assert sr_b.data_descr == 5
 
-    def test_SrCurrentSalinity_fuzz(self) -> None:
+    def test_sr_current_salinity_fuzz(self) -> None:
         """Fuzz test SensorReportSalinity bit stream roundtrip."""
         for _ in range(FUZZ_COUNT):
             sr = random_salinity()
@@ -1170,7 +1170,7 @@ class TestSensorReports:
                 sys.stderr.write("  " + str(sr_b) + "\n")
             assert sr == sr_b
 
-    def test_SensorReportWeather(self) -> None:
+    def test_sensor_report_weather(self) -> None:
         """SensorReport Weather"""
         site_id = int(math.floor(random.random() * 128))
         sr = env.SensorReportWeather(site_id=site_id)
@@ -1179,7 +1179,7 @@ class TestSensorReports:
         assert sr.month == 1
         env.SensorReportWeather(bits=sr.get_bits())
 
-    def test_SensorReportWeather_min(self) -> None:
+    def test_sensor_report_weather_min(self) -> None:
         """SensorReport Weather minimum"""
         sr = env.SensorReportWeather(
             year=2010,
@@ -1211,7 +1211,7 @@ class TestSensorReports:
         assert sr_b.air_pres_data_descr == 1
         assert sr_b.salinity == pytest.approx(0.0)
 
-    def test_SensorReportWeather_max(self) -> None:
+    def test_sensor_report_weather_max(self) -> None:
         """SensorReport Weather maximum"""
         sr = env.SensorReportWeather(
             year=2010,
@@ -1243,7 +1243,7 @@ class TestSensorReports:
         assert sr_b.air_pres_data_descr == 5
         assert sr_b.salinity == pytest.approx(50.0)
 
-    def test_SrWeather_fuzz(self) -> None:
+    def test_sr_weather_fuzz(self) -> None:
         """Fuzz test SensorReportWeather bit stream roundtrip."""
         for _ in range(FUZZ_COUNT):
             sr = random_weather()
@@ -1254,7 +1254,7 @@ class TestSensorReports:
                 sys.stderr.write("  " + str(sr_b) + "\n")
             assert sr == sr_b
 
-    def test_SensorReportAirGap(self) -> None:
+    def test_sensor_report_air_gap(self) -> None:
         """SensorReport AirGap"""
         site_id = int(math.floor(random.random() * 128))
         sr = env.SensorReportAirGap(site_id=site_id)
@@ -1263,7 +1263,7 @@ class TestSensorReports:
         assert sr.month == 1
         env.SensorReportAirGap(bits=sr.get_bits())
 
-    def test_SensorReportAirGap_min(self) -> None:
+    def test_sensor_report_air_gap_min(self) -> None:
         """SensorReport AirGap minimum"""
         sr = env.SensorReportAirGap(
             year=2010,
@@ -1289,7 +1289,7 @@ class TestSensorReports:
         assert sr_b.forecast_hour == pytest.approx(0)
         assert sr_b.forecast_minute == pytest.approx(0)
 
-    def test_SensorReportAirGap_max(self) -> None:
+    def test_sensor_report_air_gap_max(self) -> None:
         """SensorReport AirGap maximumx"""
         sr = env.SensorReportAirGap(
             year=2049,
@@ -1315,7 +1315,7 @@ class TestSensorReports:
         assert sr_b.forecast_hour == 23
         assert sr_b.forecast_minute == 59
 
-    def test_SrAirGap_fuzz(self) -> None:
+    def test_sr_air_gap_fuzz(self) -> None:
         """Fuzz test SensorReportAirGap bit stream roundtrip."""
         for _ in range(FUZZ_COUNT):
             sr = random_airgap()

--- a/tests/m367_22_test.py
+++ b/tests/m367_22_test.py
@@ -37,9 +37,9 @@ class DiffAreaNotice:
         self.an2_missing = fields_an1.difference(fields_an2)
 
         for field in fields:
-            self.CheckField(field)
+            self.check_field(field)
 
-    def CheckField(self, field: str) -> None:
+    def check_field(self, field: str) -> None:
         """Compare a specific attribute field between two AreaNotice instances.
 
         Args:
@@ -54,7 +54,7 @@ class DiffAreaNotice:
 class TestAreaNotice:
     """Tests for AreaNotice (8:367:22) encoding, decoding, and subareas."""
 
-    def checkHeader(self, area_notice: AreaNotice, mmsi: int = 366123456) -> None:
+    def check_header(self, area_notice: AreaNotice, mmsi: int = 366123456) -> None:
         """Verify common AIS message header fields.
 
         Args:
@@ -66,7 +66,7 @@ class TestAreaNotice:
         assert area_notice.mmsi == mmsi
         assert area_notice.spare == 0
 
-    def checkDacFi(self, area_notice: AreaNotice) -> None:
+    def check_dac_fi(self, area_notice: AreaNotice) -> None:
         """Verify DAC and FI fields in AreaNotice.
 
         Args:
@@ -75,7 +75,7 @@ class TestAreaNotice:
         assert area_notice.dac == 367  # One of thr USA DACs.
         assert area_notice.fi == 22  # Area notice.
 
-    def checkAreaNoticeHeader(
+    def check_area_notice_header(
         self,
         area_notice: AreaNotice,
         link_id: int,
@@ -95,7 +95,7 @@ class TestAreaNotice:
         if "spare2" in area_notice.__dict__:
             assert area_notice.spare2 == 0
 
-    def checkCircle(
+    def check_circle(
         self,
         subarea: AreaNoticeCircle,
         scale_factor: int,
@@ -125,7 +125,7 @@ class TestAreaNotice:
         if "spare" in self.__dict__:
             assert subarea.spare == 0
 
-    def checkRectangle(
+    def check_rectangle(
         self,
         subarea: AreaNoticeRectangle,
         scale_factor: int,
@@ -162,7 +162,7 @@ class TestAreaNotice:
         if "spare" in self.__dict__:
             assert subarea.spare == 0
 
-    def checkSector(
+    def check_sector(
         self,
         subarea: AreaNoticeSector,
         scale_factor: int,
@@ -198,7 +198,7 @@ class TestAreaNotice:
         if "spare" in self.__dict__:
             assert subarea.spare == 0
 
-    def checkPoly(
+    def check_poly(
         self,
         sub_area: AreaNoticePoly,
         area_shape: int,
@@ -229,7 +229,7 @@ class TestAreaNotice:
             assert sub_dist == dist
         assert sub_area.spare == 0
 
-    def checkText(self, sub_area: AreaNoticeText, expected_text: str) -> None:
+    def check_text(self, sub_area: AreaNoticeText, expected_text: str) -> None:
         """Verify AreaNoticeText subarea fields.
 
         Args:
@@ -242,15 +242,15 @@ class TestAreaNotice:
         if "spare" in self.__dict__:
             assert sub_area.spare == 0
 
-    def testCircle(self) -> None:
+    def test_circle(self) -> None:
         """Test decoding circle area notice NMEA sample."""
         msg = "!AIVDM,1,1,0,A,85M:Ih1KmPAU6jAs85`03cJm;1NHQhPFP000,0*19"
         area_notice = AreaNotice(nmea_strings=[msg])
-        self.checkHeader(area_notice)
-        self.checkDacFi(area_notice)
+        self.check_header(area_notice)
+        self.check_dac_fi(area_notice)
         # area type 13: Caution Area: Survey Operations
         # duration 2880 -> 48hrs
-        self.checkAreaNoticeHeader(
+        self.check_area_notice_header(
             area_notice,
             link_id=101,
             area_type=13,
@@ -260,7 +260,7 @@ class TestAreaNotice:
         assert len(area_notice.areas) == 1
         circle = area_notice.areas[0]
         assert isinstance(circle, AreaNoticeCircle)
-        self.checkCircle(
+        self.check_circle(
             circle,
             scale_factor=10,
             lon=-71.935,
@@ -269,7 +269,7 @@ class TestAreaNotice:
             radius=1800,
         )
 
-    def testOnlyCircleEncode(self) -> None:
+    def test_only_circle_encode(self) -> None:
         """Test AreaNoticeCircle standalone encoding and decoding."""
         lon = 1.0
         lat = -2.0
@@ -278,9 +278,9 @@ class TestAreaNotice:
         c1 = AreaNoticeCircle(lon, lat, radius, precision)
         bits = c1.get_bits()
         c2 = AreaNoticeCircle(bits=bits)
-        self.checkCircle(c2, 1, lon, lat, precision, radius)
+        self.check_circle(c2, 1, lon, lat, precision, radius)
 
-    def testEncodeCircleMatchingUSCG(self) -> None:
+    def test_encode_circle_matching_uscg(self) -> None:
         """Make sure we can recreate the bits in the USCG circle test."""
         msg = "!AIVDM,1,1,0,A,85M:Ih1KmPAU6jAs85`03cJm;1NHQhPFP000,0*19"
         # grab just the sub area portion
@@ -292,17 +292,17 @@ class TestAreaNotice:
         scale_factor = 10
         precision = 4
         radius = 1800
-        self.checkCircle(c1, scale_factor, lon, lat, precision, radius)
+        self.check_circle(c1, scale_factor, lon, lat, precision, radius)
 
         # Now we build the same, must force the scale factor to match USCG
         c2 = AreaNoticeCircle(c1.lon, c1.lat, c1.radius, c1.precision, scale_factor)
-        self.checkCircle(c2, scale_factor, lon, lat, precision, radius)
+        self.check_circle(c2, scale_factor, lon, lat, precision, radius)
 
         c2_bits = c2.get_bits()
         c3 = AreaNoticeCircle(bits=c2_bits)
-        self.checkCircle(c3, 10, lon, lat, precision, radius)
+        self.check_circle(c3, 10, lon, lat, precision, radius)
 
-    def testCircleEncode(self) -> None:
+    def test_circle_encode(self) -> None:
         """Test AreaNotice with circle subarea encoding and NMEA generation."""
         # Test against 'Sample AN Data RTCMv1.xlsx' circle
         year = datetime.datetime.utcnow().year
@@ -333,13 +333,13 @@ class TestAreaNotice:
 
         assert lines[0] == expected_msg
 
-    def testRectangle(self) -> None:
+    def test_rectangle(self) -> None:
         """Test decoding rectangle area notice NMEA sample."""
         msg = "!AIVDM,1,1,0,A,85M:Ih1KmPAVhjAs80e0;cKBN1N:W8Q@:2`0,0*0C"
         area_notice = AreaNotice(nmea_strings=[msg])
-        self.checkHeader(area_notice)
-        self.checkDacFi(area_notice)
-        self.checkAreaNoticeHeader(
+        self.check_header(area_notice)
+        self.check_dac_fi(area_notice)
+        self.check_area_notice_header(
             area_notice,
             link_id=102,
             area_type=97,
@@ -359,7 +359,7 @@ class TestAreaNotice:
         e_dim = 400
         n_dim = 200
         orientation_deg = 42
-        self.checkRectangle(
+        self.check_rectangle(
             subarea,
             scale_factor,
             lon,
@@ -370,7 +370,7 @@ class TestAreaNotice:
             orientation_deg,
         )
 
-    def testEncodeRectMatchingUSCG(self) -> None:
+    def test_encode_rect_matching_uscg(self) -> None:
         """Test encoding AreaNoticeRectangle matching USCG test vector."""
         msg = "!AIVDM,1,1,0,A,85M:Ih1KmPAVhjAs80e0;cKBN1N:W8Q@:2`0,0*0C"
         sub_area_msg = msg.split(",")[5][-16:]
@@ -383,25 +383,25 @@ class TestAreaNotice:
         e_dim = 400
         n_dim = 200
         orientation_deg = 42
-        self.checkRectangle(
+        self.check_rectangle(
             sa1, scale_factor, lon, lat, precision, e_dim, n_dim, orientation_deg
         )
 
         sa2 = AreaNoticeRectangle(
             lon, lat, e_dim, n_dim, orientation_deg, precision, scale_factor
         )
-        self.checkRectangle(
+        self.check_rectangle(
             sa2, scale_factor, lon, lat, precision, e_dim, n_dim, orientation_deg
         )
         sa2_bits = sa2.get_bits()
 
         sa3 = AreaNoticeRectangle(bits=sa2_bits)
-        self.checkRectangle(
+        self.check_rectangle(
             sa3, scale_factor, lon, lat, precision, e_dim, n_dim, orientation_deg
         )
         assert sa1_bits == sa2_bits
 
-    def testRectangleEncode(self) -> None:
+    def test_rectangle_encode(self) -> None:
         """Test AreaNotice with rectangle subarea encoding and NMEA generation."""
         year = datetime.datetime.utcnow().year
         when = datetime.datetime(year, 9, 4, 15, 25)
@@ -425,7 +425,7 @@ class TestAreaNotice:
             lon, lat, e_dim, n_dim, orientation_deg, precision, scale_factor
         )
         an.add_subarea(rect)
-        self.checkAreaNoticeHeader(
+        self.check_area_notice_header(
             an, link_id=102, area_type=97, timestamp=(9, 4, 15, 25), duration=360
         )
         lines = an.get_aivdm(sequence_num=0, channel="A")
@@ -438,13 +438,13 @@ class TestAreaNotice:
         assert expected_bits == bits
         assert lines[0] == expected_msg
 
-    def testSector(self) -> None:
+    def test_sector(self) -> None:
         """Test decoding sector area notice NMEA sample."""
         msg = "!AIVDM,1,1,0,A,85M:Ih1KmPAW5BAs80e0EcN<11N6th@6BgL8,0*13"
         area_notice = AreaNotice(nmea_strings=[msg])
-        self.checkHeader(area_notice)
-        self.checkDacFi(area_notice)
-        self.checkAreaNoticeHeader(
+        self.check_header(area_notice)
+        self.check_dac_fi(area_notice)
+        self.check_area_notice_header(
             area_notice,
             link_id=103,
             area_type=10,
@@ -462,11 +462,11 @@ class TestAreaNotice:
         radius = 5000
         left = 175
         right = 225
-        self.checkSector(
+        self.check_sector(
             subarea, scale_factor, lon, lat, precision, radius, left, right
         )
 
-    def testEncodeSectorMatchingUSCG(self) -> None:
+    def test_encode_sector_matching_uscg(self) -> None:
         """Test encoding AreaNoticeSector matching USCG test vector."""
         msg = "!AIVDM,1,1,0,A,85M:Ih1KmPAW5BAs80e0EcN<11N6th@6BgL8,0*13"
         sub_area_msg = msg.split(",")[5][-16:]
@@ -479,17 +479,17 @@ class TestAreaNotice:
         radius = 5000
         left = 175
         right = 225
-        self.checkSector(sa1, scale_factor, lon, lat, precision, radius, left, right)
+        self.check_sector(sa1, scale_factor, lon, lat, precision, radius, left, right)
 
         sa2 = AreaNoticeSector(lon, lat, radius, left, right, precision, scale_factor)
-        self.checkSector(sa2, scale_factor, lon, lat, precision, radius, left, right)
+        self.check_sector(sa2, scale_factor, lon, lat, precision, radius, left, right)
         sa2_bits = sa2.get_bits()
 
         sa3 = AreaNoticeSector(bits=sa2_bits)
-        self.checkSector(sa3, scale_factor, lon, lat, precision, radius, left, right)
+        self.check_sector(sa3, scale_factor, lon, lat, precision, radius, left, right)
         assert sa1_bits == sa2_bits
 
-    def testPolylineAndText(self) -> None:
+    def test_polyline_and_text(self) -> None:
         """Test decoding multi-sentence AreaNotice with polyline and text subareas."""
         msg = [
             (
@@ -498,9 +498,9 @@ class TestAreaNotice:
             "!AIVDM,2,2,0,A,00000000bPbJT1Q9hd680000,0*03",
         ]
         area_notice = AreaNotice(nmea_strings=msg)
-        self.checkHeader(area_notice)
-        self.checkDacFi(area_notice)
-        self.checkAreaNoticeHeader(
+        self.check_header(area_notice)
+        self.check_dac_fi(area_notice)
+        self.check_area_notice_header(
             area_notice,
             link_id=104,
             area_type=120,
@@ -518,7 +518,7 @@ class TestAreaNotice:
         points0 = [(45.0, 2000), (55.5, 1500), (20.0, 755), (75.0, 1825)]
         lon: float | None = -71.6816666666
         lat: float | None = 41.1483333333
-        self.checkPoly(line0, 3, 1, lon, lat, points0)
+        self.check_poly(line0, 3, 1, lon, lat, points0)
 
         # The USCG / Greg Johnson is not following the specs with 0, 0 marking
         # no point.
@@ -526,12 +526,12 @@ class TestAreaNotice:
         points1 = [(15.5, 550)]
         # TODO: Check the lat, lon are being pulled correctly.
         lon, lat = None, None
-        self.checkPoly(line1, 3, 1, lon, lat, points1)
+        self.check_poly(line1, 3, 1, lon, lat, points1)
 
         assert text_block
-        self.checkText(text_block, "TEST LINE 1")
+        self.check_text(text_block, "TEST LINE 1")
 
-    def testPolylineOnly(self) -> None:
+    def test_polyline_only(self) -> None:
         """Test AreaNoticePoly standalone encoding and decoding."""
         msg = [
             (
@@ -546,24 +546,24 @@ class TestAreaNotice:
         sa1 = AreaNoticePoly(bits=sa1_bits)
         points1 = [(15.5, 550), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0)]
         scale_factor = 1  # Not what is in the example spreadsheet.
-        self.checkPoly(
+        self.check_poly(
             sa1, SHAPES["POLYLINE"], scale_factor, None, None, points=points1
         )
 
         sa2 = AreaNoticePoly(SHAPES["POLYLINE"], points1, scale_factor)
-        self.checkPoly(
+        self.check_poly(
             sa1, SHAPES["POLYLINE"], scale_factor, None, None, points=points1
         )
         sa2_bits = sa2.get_bits()
         assert sa1_bits == sa2_bits
 
-    def testPolygon(self) -> None:
+    def test_polygon(self) -> None:
         """Test decoding polygon area notice NMEA sample."""
         msg = "!AIVDM,1,1,0,A,85M:Ih1KmPAa8jAs85`01cN:41NI@`P00000P7Td4dUP00000000,0*71"
         area_notice = AreaNotice(nmea_strings=[msg])
-        self.checkHeader(area_notice)
-        self.checkDacFi(area_notice)
-        self.checkAreaNoticeHeader(
+        self.check_header(area_notice)
+        self.check_dac_fi(area_notice)
+        self.check_area_notice_header(
             area_notice,
             link_id=105,
             area_type=17,
@@ -577,9 +577,9 @@ class TestAreaNotice:
         points = ((30, 1200), (150, 1200))
         lon = -71.753333333
         lat = 41.241666667
-        self.checkPoly(poly, 4, 1, lon, lat, points)
+        self.check_poly(poly, 4, 1, lon, lat, points)
 
-    def testTextOnly(self) -> None:
+    def test_text_only(self) -> None:
         """Test AreaNoticeText standalone encoding and decoding."""
         msg = [
             (
@@ -591,9 +591,9 @@ class TestAreaNotice:
         sa1_bits = binary.ais6tobitvec(sub_area_msg)
         sa1 = AreaNoticeText(bits=sa1_bits)
         text = "TEST LINE 1"
-        self.checkText(sa1, text)
+        self.check_text(sa1, text)
         sa2 = AreaNoticeText(text)
-        self.checkText(sa2, text)
+        self.check_text(sa2, text)
         sa2_bits = sa2.get_bits()
         assert sa1_bits == sa2_bits
 


### PR DESCRIPTION
### Summary of Changes

  1. Core Modules Refactored to snake_case / UPPER_CASE:
      * `__init__.py`: Standardized `__version__` = "0.5" and VERSION = `__version__`.
      * ais_string.py: Converted Decode, Encode, Strip, Pad to decode, encode, strip, pad (added pylint-disabled backward compatibility aliases).
      * an_util.py: Converted methods in DecodeBits and BuildBits to snake_case with backward compatibility aliases.
      * binary.py: Renamed functions, parameters, and local variables to snake_case (set_bit_vector_size, _ais6_to_bitvec_slow, _build_lookup_table, join_bv, add_one, sub_one, bv_from_signed_int,
      signed_int_from_bv, bit_size, do_padding, pad_len) with backward compatibility aliases and keyword argument compatibility (bitSize, doPadding).
      * imo_001_22_area_notice.py: Upgraded module constants to UPPER_CASE (NEXT_SEQUENCE, KML_HEAD, KML_TAIL, ISO8601_TIMEFORMAT).
      * m366_22.py & m367_22.py: Converted class methods to snake_case with backward compatibility aliases.
  2. Test Suite Renamings:
      * imo_001_22_area_notice_test.py: Converted 30 test methods to snake_case (e.g., test_without_metadata, test_circle_geom, test_simple).
      * imo_001_26_environment_test.py: Converted 45 test methods to snake_case (e.g., test_sensor_report_weather_max, test_sr_air_gap_fuzz).
      * m367_22_test.py: Converted test and helper methods to snake_case (check_header, check_dac_fi, test_circle, test_rectangle_encode, etc.).
